### PR TITLE
Input schema edits

### DIFF
--- a/ckanext/unaids/validation_table_schemas/inputs_unaids_anc.json
+++ b/ckanext/unaids/validation_table_schemas/inputs_unaids_anc.json
@@ -45,7 +45,7 @@
       }
     },
     {
-      "name": "ancrt_known_pos",
+      "name": "anc_known_pos",
       "title": "Number known positive",
       "description": "Number of ANC clients who self-report known HIV positive prior to first ANC visit and are not tested for HIV.",
       "type": "integer",
@@ -54,7 +54,7 @@
       }
     },
     {
-      "name": "ancrt_already_art",
+      "name": "anc_already_art",
       "title": "Number already on ART",
       "description": "Number of ANC clients already on ART prior to first ANC visit during a pregnancy.",
       "type": "integer",
@@ -63,7 +63,7 @@
       }
     },
     {
-      "name": "ancrt_tested",
+      "name": "anc_tested",
       "title": "Number HIV tested",
       "description": "Number of unique ANC clients who are tested for HIV during their pregnancy.",
       "type": "integer",
@@ -72,7 +72,7 @@
       }
     },
     {
-      "name": "ancrt_test_pos",
+      "name": "anc_tested_pos",
       "title": "Number Tested Positive",
       "description": "Number of ANC clients who test HIV positive at the first HIV test during a given pregnancy.",
       "type": "integer",
@@ -84,7 +84,7 @@
   "require_field_order": false,
   "primaryKey": ["area_id", "year", "age_group"],
   "custom-constraint": {
-      "constraint": "ancrt_already_art <= ancrt_known_pos",
-      "constraint": "ancrt_test_pos <= ancrt_tested_pos"
+      "constraint": "anc_already_art <= anc_known_pos",
+      "constraint": "anc_test_pos <= anc_tested_pos"
   }
 }

--- a/ckanext/unaids/validation_table_schemas/inputs_unaids_art.json
+++ b/ckanext/unaids/validation_table_schemas/inputs_unaids_art.json
@@ -52,9 +52,10 @@
       "type": "number",
       "constraints": {
         "required": true,
-        "minimum": 0
-     },
-     {
+          "minimum": 0
+      }
+    },
+    {
        "name": "art_new",
        "title": "Number newly initiating ART",
        "description": "Number newly initiating ART diruing the reporting period (year).",
@@ -62,7 +63,7 @@
        "constraints": {
          "required": true,
          "minimum": 0
-      }
+       }
     }
   ],
   "require_field_order": false,

--- a/ckanext/unaids/validation_table_schemas/inputs_unaids_art.json
+++ b/ckanext/unaids/validation_table_schemas/inputs_unaids_art.json
@@ -17,11 +17,11 @@
     {
       "name": "sex",
       "title": "Sex",
-      "description": "Biological sex.  Must be \"male\", \"female\",  or \"both\" where sex stratification is not available.",
+      "description": "Biological sex.  Must be \"both\", \"female\", or \"male\".",
       "type": "string",
       "constraints": {
         "required": true,
-        "enum": ["male", "female", "both"]
+          "enum": ["both", "male", "female"]
       }
     },
     {
@@ -46,13 +46,22 @@
       }
     },
     {
-      "name": "current_art",
+      "name": "art_current",
       "title": "Number on ART",
       "description": "Number currently receiving ART at the end of reporting period (year).",
       "type": "number",
       "constraints": {
         "required": true,
         "minimum": 0
+     },
+     {
+       "name": "art_new",
+       "title": "Number newly initiating ART",
+       "description": "Number newly initiating ART diruing the reporting period (year).",
+       "type": "number",
+       "constraints": {
+         "required": true,
+         "minimum": 0
       }
     }
   ],

--- a/ckanext/unaids/validation_table_schemas/inputs_unaids_population.json
+++ b/ckanext/unaids/validation_table_schemas/inputs_unaids_population.json
@@ -29,11 +29,11 @@
     {
       "name": "sex",
       "title": "Sex",
-      "description": "Biological sex.  Must be \"male\", \"female\",  or \"both\" where sex stratification is not available.",
+      "description": "Biological sex.  Must be \"both\", \"female\", or \"male\"".,
       "type": "string",
       "constraints": {
         "required": true,
-        "enum": ["male", "female", "both"]
+        "enum": ["both", "male", "female"]
       }
     },
     {
@@ -54,7 +54,17 @@
         "required": true,
         "minimum": 0
       }
-    }
+    },
+    {
+      "name": "asfr",
+      "title": "Age-specific fertility rate",
+      "description": "Age-specific fertility rate.",
+      "type": "number",
+      "constraints": {
+        "required": false,
+        "minimum": 0
+      }
+    }	     
   ],
   "require_field_order": false,
   "primaryKey": ["area_id", "calendar_quarter", "sex", "age_group"]

--- a/ckanext/unaids/validation_table_schemas/inputs_unaids_survey.json
+++ b/ckanext/unaids/validation_table_schemas/inputs_unaids_survey.json
@@ -1,6 +1,6 @@
 {
   "fields": [{
-      "name": "indicator_id",
+      "name": "indicator",
       "title": "Indicator ID",
       "description": "The indicator measured by the survey",
       "type": "string",
@@ -18,13 +18,11 @@
     },
     {
       "name": "survey_mid_calendar_quarter",
-      "title": "Year",
-      "description": "The calendar year.",
-      "type": "integer",
+      "title": "Survey Midpoint Calendar Quarter",
+      "description": "The calendar quarter nearest to the midpoint of the survey fieldwork period.",
+      "type": "string",
       "constraints": {
-          "required": true,
-          "minimum": 1970,
-          "maximum": 2021
+          "required": true
       }
     },{
       "name": "area_id",
@@ -42,7 +40,7 @@
       "type": "string"
     },
     {
-      "name": "restype",
+      "name": "res_type",
       "title": "Residence Type",
       "description": "Residence Type",
       "type": "string",
@@ -53,11 +51,11 @@
     {
       "name": "sex",
       "title": "Sex",
-      "description": "Biological sex.  Must be \"male\", \"female\",  or \"both\" where sex stratification is not available.",
+      "description": "Biological sex.  Must be \"both\", \"male\", or \"female\".",
       "type": "string",
       "constraints": {
         "required": true,
-        "enum": ["male", "female", "both"]
+          "enum": ["both", "female", "male"]
       }
     },
     {
@@ -70,7 +68,7 @@
       }
     },
     {
-      "name": "n_cluster",
+      "name": "n_clusters",
       "title": "Number of clusters",
       "description": "The number of survey clusters",
       "type": "string",
@@ -99,7 +97,7 @@
         "type": "float"
       }
     },{
-      "name": "standard_error",
+      "name": "se",
       "title": "Standard Error",
       "description": "The standard error on the estimate",
       "type": "string",
@@ -109,18 +107,18 @@
       }
     },
     {
-      "name": "confidence_interval_lower",
-      "title": "Confidence Interval Lower Bound",
-      "description": "The value of the confidence interval lower bound",
+      "name": "ci_lower",
+      "title": "95% Confidence Interval Lower Bound",
+      "description": "The value of the 95% confidence interval lower bound",
       "type": "string",
       "constraints": {
         "type": "float"
       }
     },
     {
-      "name": "confidence_interval_upper",
-      "title": "Confidence Interval Upper Bound",
-      "description": "The value of the confidence interval upper bound",
+      "name": "ci_upper",
+      "title": "95% Confidence Interval Upper Bound",
+      "description": "The value of the 95% confidence interval upper bound",
       "type": "string",
       "constraints": {
         "type": "float"


### PR DESCRIPTION
This implements small edits to the Naomi input table schemes:

* Adds ASFR column to population dataset. Perhaps this is preferred as a different table though?
* Renames `ancrt_*` to `anc_*`.
* Renames `current_art` to `art_current`.
* Adds `art_new` field.