### PR TITLE
Add a VMMC link in the data set selector.

### DIFF
--- a/ckanext/unaids/theme/templates/snippets/dataset_selector.html
+++ b/ckanext/unaids/theme/templates/snippets/dataset_selector.html
@@ -1,14 +1,14 @@
 <div class="dropdown">
-	<button class="btn btn-primary dropdown-toggle" type="button" id="addDatasetMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-		<i class="fa fa-plus-square"></i> {{_('Add Dataset')}}
-	</button>
-	<div class="dropdown-menu" aria-labelledby="addDatasetMenuButton">
-		{% snippet 'snippets/add_dataset.html', dataset_type='spectrum-file' %}
-		{% snippet 'snippets/add_dataset.html', dataset_type='geographic-data-package' %}
-		{# snippet 'snippets/add_dataset.html', dataset_type='document-data-package' #}
-		{% snippet 'snippets/add_dataset.html', dataset_type='naomi-data-package' %}
-		{% snippet 'snippets/add_dataset.html', dataset_type='naomi-data-package-2' %}
-		{% snippet 'snippets/add_dataset.html', dataset_type='dataset-2' %}
+  <button class="btn btn-primary dropdown-toggle" type="button" id="addDatasetMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <i class="fa fa-plus-square"></i> {{_('Add Dataset')}}
+  </button>
+  <div class="dropdown-menu" aria-labelledby="addDatasetMenuButton">
+    {% snippet 'snippets/add_dataset.html', dataset_type='spectrum-file' %}
+    {% snippet 'snippets/add_dataset.html', dataset_type='geographic-data-package' %}
+    {# snippet 'snippets/add_dataset.html', dataset_type='document-data-package' #}
+    {% snippet 'snippets/add_dataset.html', dataset_type='naomi-data-package' %}
+    {% snippet 'snippets/add_dataset.html', dataset_type='naomi-data-package-2' %}
+    {% snippet 'snippets/add_dataset.html', dataset_type='dataset-2' %}
     {% link_for _('VMMC Data'), controller='package', action='new', named_route='dataset-2_new', class_='dropdown-item', tag_string='VMMC', notes='2020/21 Voluntary Medical Male Circumcision (VMMC) Data for use in the DMPPT2 model developed by Avenir Health to estimate VMMC coverage and set targets.'%}
-	</div>
+  </div>
 </div>

--- a/ckanext/unaids/theme/templates/snippets/dataset_selector.html
+++ b/ckanext/unaids/theme/templates/snippets/dataset_selector.html
@@ -9,5 +9,6 @@
 		{% snippet 'snippets/add_dataset.html', dataset_type='naomi-data-package' %}
 		{% snippet 'snippets/add_dataset.html', dataset_type='naomi-data-package-2' %}
 		{% snippet 'snippets/add_dataset.html', dataset_type='dataset-2' %}
+    {% link_for _('VMMC Data'), controller='package', action='new', named_route='dataset-2_new', class_='dropdown-item', tag_string='VMMC', notes='2020/21 Voluntary Medical Male Circumcision (VMMC) Data for use in the DMPPT2 model developed by Avenir Health to estimate VMMC coverage and set targets.'%}
 	</div>
 </div>


### PR DESCRIPTION
Ian wants a direct link to a general dataset pre-populated with some fields for VMMC data.

Do we have any issues with this.  It breaks the model of the dateset selector slightly, but I can't see any practical problems with it other than language translation. 