### PR TITLE
Adx 407 Clean up restricted code

### DIFF
--- a/ckanext/unaids/presets.json
+++ b/ckanext/unaids/presets.json
@@ -28,6 +28,33 @@
         }
     	}
     },{
+      "preset_name": "restricted_fields",
+      "values": {
+        "validators": "ignore_missing",
+        "form_snippet": "restricted_fields.html",
+        "display_snippet": "restricted_fields.html",
+        "default": "{\"level\": \"restricted\", \"allowed_users\": \"\", \"allowed_organizations\": \"unaids\"}",
+        "choices": [{
+            "value": "restricted",
+            "label": "Restricted to specified users and organizations"
+          },
+          {
+            "value": "public",
+            "label": "Public"
+          }
+        ],
+        "form_attrs_users": {
+          "data-module": "autocomplete-without-creating-new-options",
+          "data-module-tags": "",
+          "data-module-source": "/api/2/util/user/autocomplete?q=?"
+        },
+        "form_attrs_orgs": {
+          "data-module": "autocomplete-without-creating-new-options",
+          "data-module-tags": "",
+          "data-module-source": "/api/2/util/organization/autocomplete?q=?"
+        }
+      }
+    },{
         "preset_name": "data_schema",
         "values": {
             "form_include_blank_choice": true,

--- a/ckanext/unaids/theme/public/custom.css
+++ b/ckanext/unaids/theme/public/custom.css
@@ -197,3 +197,11 @@ section.resources H3{
 .download-all{
   margin-top: 5px;
 }
+
+.resource-item .description{
+  margin-bottom: 2px;
+}
+
+.resource-title{
+  margin-bottom: 10px;
+}

--- a/ckanext/unaids/theme/templates/package/snippets/resource_item.html
+++ b/ckanext/unaids/theme/templates/package/snippets/resource_item.html
@@ -1,10 +1,12 @@
 {% ckan_extends %}
+{% block resource_item_title %}
+  <div class="resource-title">
+    {{ super() }}
+  </div>
+{% endblock %}
+
 {% block resource_item_description %}
-<p class="description">
-  {% if res.description %}
-  {{ h.markdown_extract(h.get_translated(res, 'description'), extract_length=80) }}
-  {% endif %}
-</p>
+{{super()}}
 {% if res.last_modified %}
 <p class="description" title="{{ h.render_datetime(res.last_modified, with_hours=True) }}">
   {{ _('Last modified') + ": "}}{{ h.time_ago_from_timestamp(res.last_modified) }}


### PR DESCRIPTION
Ckanext Restricted has been really bugging me for a while. This was set up very early in the project's lifestyle. I've spent a while de coupling it from scheming, cleaning up the UI and the configs.

I have also moved the creation of the restricted json string from a validator to the client side as it is a far cleaner way of working with and debugging the software. This also helps decouple the extension from the scheming extension and create behaviour more inline with restricted tests.

There are a number of related PRS.