### PR TITLE
Fix missing colors from unaids theme

### DIFF
--- a/ckanext/unaids/theme/public/unaids.css
+++ b/ckanext/unaids/theme/public/unaids.css
@@ -9311,6 +9311,9 @@ h4 small {
     padding-top: 10px;
     background: #eee url("../../../base/images/bg.png");
   }
+  .main .primary {
+    background: none;
+  }
 }
 [role=main] {
   min-height: 350px;

--- a/ckanext/unaids/theme/templates/base.html
+++ b/ckanext/unaids/theme/templates/base.html
@@ -1,9 +1,15 @@
 {% ckan_extends %}
 
-{% block styles %}
+{% block custom_styles %}
   {{ super() }}
   <link rel="stylesheet" href="/unaids.css" />
   <link rel="stylesheet" href="/custom.css" />
-  {% resource 'ckanext-unaids/autocomplete-without-creating-new-options.js' %}
 
+{% endblock %}
+
+
+{% block scripts %}
+  {{ super() }}
+  {% resource 'ckanext-unaids/autocomplete-without-creating-new-options.js' %}
+  
 {% endblock %}


### PR DESCRIPTION
# Problem
- We lost our custom UNAIDS styles when upgrading to ckan 2.9

![image](https://user-images.githubusercontent.com/2634482/95865760-ec735380-0d5e-11eb-8179-6119e69c5b11.png)

# Solution
- The order in which the base css file has moved lower down in the htm, so we need to shuffle our custom css imports lower down in the order to overwrite the base css
- This was technically always an issue which wasn't causing any ugly effects, so it went unnoticed 😅  

![image](https://user-images.githubusercontent.com/2634482/95865816-fe54f680-0d5e-11eb-8849-b701e6a3e491.png)
