### PR TITLE
migrated scripts to webassets

### DIFF
--- a/ckanext/unaids/fanstatic/webassets.yml
+++ b/ckanext/unaids/fanstatic/webassets.yml
@@ -1,0 +1,11 @@
+global_scripts:
+    contents:
+        - autocomplete-without-creating-new-options.js
+
+download_all:
+    contents:
+      - download_all.js
+
+text_template:
+    contents:
+      - text_template.js

--- a/ckanext/unaids/theme/templates/base.html
+++ b/ckanext/unaids/theme/templates/base.html
@@ -4,6 +4,11 @@
   {{ super() }}
   <link rel="stylesheet" href="/unaids.css" />
   <link rel="stylesheet" href="/custom.css" />
-  {% resource 'ckanext-unaids/autocomplete-without-creating-new-options.js' %}
+
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% asset 'ckanext-unaids/global_scripts' %}
 
 {% endblock %}

--- a/ckanext/unaids/theme/templates/package/read.html
+++ b/ckanext/unaids/theme/templates/package/read.html
@@ -29,7 +29,7 @@
   {% endblock %}
   {# FIXME why is this here? seems wrong #}
   <span class="insert-comment-thread"></span>
-  {% resource 'ckanext-unaids/download_all.js' %}
+  {% asset 'ckanext-unaids/download_all' %}
   <button class="download-all btn btn-primary dropdown-toggle pull-right hidden"
      data-module="download_all" data-module-files='{{h.get_all_package_downloads(pkg)}}'>
     <i class="fa fa-download"></i>

--- a/ckanext/unaids/theme/templates/scheming/form_snippets/text_template.html
+++ b/ckanext/unaids/theme/templates/scheming/form_snippets/text_template.html
@@ -1,5 +1,5 @@
 {% import 'macros/form.html' as form %}
-{% resource 'ckanext-unaids/text_template.js' %}
+{% asset 'ckanext-unaids/text_template' %}
 {% set error = errors[field.field_name] %}
 <div class="text-template form-group{{ " error" if error }}">
   <div class="controls control-full {{ " " ~ field.classes | join(' ') }}">


### PR DESCRIPTION
# Problem
- As per the [python3 migrate guide](https://github.com/ckan/ckan/wiki/Python-3-migration-guide-for-extensions#web-assets-js-and-css), we need move over to using `webassets.yml` as it has a smarter way of grouping imports of css/js files
- I'll migrate over the scripts sitting in `/fanstatic` directory

# Solution
- Implemented `webassets.yml` and updated all references where we want to import the files