### PR TITLE
ADX-417 Autogenerate Data Explorers for geojson files

### DIFF
--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -15,6 +15,7 @@ from ckanext.unaids.helpers import (
     get_user_obj
 )
 import ckan.plugins.toolkit as toolkit
+from ckanext.reclineview.plugin import ReclineViewBase
 
 log = logging.getLogger(__name__)
 
@@ -99,3 +100,32 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
         return{
             'if_empty_guess_format': if_empty_guess_format
         }
+
+
+class UNAIDSReclineView(ReclineViewBase):
+    '''
+    This override of the recline view plugin allows data explorers to be auto
+    created for geojson files.
+    '''
+
+    def info(self):
+        return {'name': 'unaids_recline_view',
+                'title': 'Data Explorer',
+                'filterable': True,
+                'icon': 'table',
+                'requires_datastore': False,
+                'default_title': p.toolkit._('Data Explorer'),
+                }
+
+    def can_view(self, data_dict):
+        resource = data_dict['resource']
+
+        if (resource.get('datastore_active') or
+                '_datastore_only_resource' in resource.get('url', '')):
+            return True
+        resource_format = resource.get('format', None)
+
+        if resource_format:
+            return resource_format.lower() in ['csv', 'xls', 'xlsx', 'tsv', 'geojson']
+        else:
+            return False

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     [ckan.plugins]
     # Add plugins here, eg
     unaids=ckanext.unaids.plugin:UNAIDSPlugin
+    unaids_recline_view=ckanext.unaids.plugin:UNAIDSReclineView
     [babel.extractors]
     ckan = ckan.lib.extract:extract_ckan
     """,


### PR DESCRIPTION
The recline_view creates the "Data Explorer" in ckan that lets you browse, filter and graph data. 

However, changing which files get an autocreated recline view requires a hard code change.  I think i will open up a PR with core ckan to change this to a config change. 

In the meantime I have this pretty neat fix which involves creating a new unaids specific recline view from the same base as the orgiinal recline view.  This unaids recline view can then be edited as desired.  

As this is a plugin shipped by default with ckan core, it can't be overridden by the usual git clone/edit/install route, and the extending the reclineview base works well.

This is linked to https://github.com/fjelltopp/adx_develop/pull/18, and https://github.com/fjelltopp/adx_deploy/pull/52