### PR TITLE
ADX-381 - Added ckanext-ytp-request initdb to travis config

### DIFF
--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -61,6 +61,7 @@ pip install --user -r src/ckanext-scheming/requirements.txt
 pip install --user -e "git+https://github.com/fjelltopp/ckanext-validation@development#egg=ckanext-validation"
 pip install --user -r src/ckanext-validation/requirements.txt
 paster --plugin=ckanext-validation validation init-db -c ckan/test-core.ini
+paster --plugin=ckanext-ytp-request initdb -c test.ini
 
 echo "Installing ckanext-unaids and its requirements..."
 sudo python setup.py develop


### PR DESCRIPTION
# Problem
- `ckanext-ytp-request` has no `initdb` command in the travis config

# Solution
- Add it