### PR TITLE
Changed organization filter to singular

### DIFF
--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -76,7 +76,7 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
 
     def dataset_facets(self, facet_dict, package_type):
         new_fd = OrderedDict()
-        new_fd['organization'] = p.toolkit._('Organizations')
+        new_fd['organization'] = p.toolkit._('Organization')
         new_fd['type_name'] = p.toolkit._('Data Type')
         new_fd['tags'] = p.toolkit._('Tags')
         new_fd["year"] = p.toolkit._('Year')


### PR DESCRIPTION
# Problem
- The `organizations` filter in the sidebar & pill under the search bar are only single-select however we say `organizations` instead of simply `organization`
- Note that `Tags` are correctly named as you can select multiple

![image](https://user-images.githubusercontent.com/2634482/96729836-7cdc1480-13ad-11eb-991b-5bbbd60cb33c.png)


# Solution
- Change `organizations` to `organization`

![image](https://user-images.githubusercontent.com/2634482/96730124-cd537200-13ad-11eb-8f95-9d140499b24d.png)

