### PR TITLE
ADX-284 Clean up the new collaborator form.

### DIFF
--- a/ckanext/unaids/theme/templates/package/collaborators/collaborator_new.html
+++ b/ckanext/unaids/theme/templates/package/collaborators/collaborator_new.html
@@ -1,0 +1,45 @@
+{% ckan_extends %}
+  {% block form %}
+  <form class="dataset-form add-member-form" method='post'>
+    <div class="row">
+      <div class="col-md-6">
+        <div class="form-group control-medium">
+          {% if not user %}
+            <label class="control-label" for="username">
+              {{ _('Existing User') }}
+            </label>
+          {% endif %}
+          <div class="controls">
+            {% if user %}
+              <input type="hidden" name="username" value="{{ user.name }}" />
+              <input id="username" name="username" type="text" value="{{ user.name }}"
+              disabled="True" class="form-control">
+            {% else %}
+                <input id="username" type="text" name="username" placeholder="{{ _('Username') }}"
+              value="" class="control-medium" data-module="autocomplete-without-creating-new-options"
+              data-module-source="/api/2/util/user/autocomplete?q=?">
+            {% endif %}
+          </div>
+        </div>
+      </div>
+      <div class="col-md-6">
+          {% set format_attrs = {'data-module': 'autocomplete'} %}
+          {{ form.select('capacity', label=_('Role'), options=capacities, selected=user_capacity, error='', attrs=format_attrs) }}
+      </div>
+    </div>
+
+
+    <div class="form-actions">
+      {% if user %}
+        <a href="{{ h.url_for('dataset.collaborator_delete', id=pkg_dict.id, user_id=user.name) }}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this collaborator?') }}">{{ _('Delete') }}</a>
+        <button class="btn btn-primary" type="submit" name="submit" >
+          {{ _('Update Collaborator') }}
+        </button>
+      {% else %}
+        <button class="btn btn-primary" type="submit" name="submit" >
+          {{ _('Add Collaborator') }}
+        </button>
+      {% endif %}
+    </div>
+  </form>
+  {% endblock %}


### PR DESCRIPTION
This just touches up a template for the new Collaborators feature.  The feature seems to work well and will be really valuable I think moving forwards.  

There is possible overlap with ckanext-restricted here.  However, adding a collboarator to the package under the role (member) is effectively shorthand for going through adding an individual user to every seperate resource. 

A possible hole in this feature is that it would be nice to add another org as a collaborator so that all users of the orgs can contribute to the dataset.  But something to consider for the mid to long-term future I think.  

Related to: https://github.com/fjelltopp/adx_develop/pull/24