### PR TITLE
ADX-494-fix-ascii-errors-on-resource-extreas-snippet

### DIFF
--- a/ckanext/unaids/theme/templates/snippets/changes/resource_extras.html
+++ b/ckanext/unaids/theme/templates/snippets/changes/resource_extras.html
@@ -1,3 +1,5 @@
+<!-- TODO: delete this file once https://github.com/ckan/ckan/issues/5785 is resolved -->
+
 {% macro dataset_link(id, name) -%}
   <a href="{{h.url_for(controller='dataset', action='read', id=id)}}">{{name}}</a>
 {%- endmacro %}

--- a/ckanext/unaids/theme/templates/snippets/changes/resource_extras.html
+++ b/ckanext/unaids/theme/templates/snippets/changes/resource_extras.html
@@ -1,0 +1,112 @@
+{% macro dataset_link(id, name) -%}
+  <a href="{{h.url_for(controller='dataset', action='read', id=id)}}">{{name}}</a>
+{%- endmacro %}
+
+{% macro resource_link(dataset_id, resource_id, resource_name) -%}
+  {% set resource_url = h.url_for(
+      qualified=True,
+      controller='resource',
+      action='read',
+      id=dataset_id,
+      resource_id=resource_id
+    )
+  %}
+  <a href="{{resource_link}}">{{resource_name}}</a>
+{%- endmacro %}
+
+<li>
+  <p>
+    {% if change.method == "add_one_value" %}
+
+      {{_('Added field <q>{key}</q> with value <q>{value}</q> to resource {resource_link} in {pkg_link}').format(
+          pkg_link=dataset_link(change.pkg_id, change.title),
+          resource_link=resource_link(change.pkg_id, change.resource_id, change.resource_name),
+          key=change.key,
+          value=change.value
+      )}}
+
+    {% elif change.method == "add_one_no_value" %}
+
+      {{_('Added field <q>{key}</q> to resource {resource_link} in {pkg_link}').format(
+          pkg_link=dataset_link(change.pkg_id, change.title),
+          resource_link=resource_link(change.pkg_id, change.resource_id, change.resource_name),
+          key=change.key,
+      ) }}
+
+    {% elif change.method == "add_multiple" %}
+
+      {{_('Added the following fields to resource {resource_link} in {pkg_link}').format(
+          pkg_link=dataset_link(change.pkg_id, change.title),
+          resource_link=resource_link(change.pkg_id, change.resource_id, change.resource_name),
+      )}}
+      <ul>
+        {% for item in change.key_list %}
+          {% if change.value_list[item] != "" %}
+            {{_('{key} with value {value}').format(
+              key=item,
+              value=change.value_list[item]
+            )|safe }}
+          {% else %}
+            {{_('{key}').format(
+              key=item
+            )|safe }}
+          {% endif %}
+        {% endfor %}
+      </ul>
+
+    {% elif change.method == "remove_one" %}
+
+      {{_('Removed field <q>{key}</q> from resource {resource_link} in {pkg_link}').format(
+          pkg_link=dataset_link(change.pkg_id, change.title),
+          resource_link=resource_link(change.pkg_id, change.resource_id, change.resource_name),
+          key=change.key
+      ) }}
+
+    {% elif change.method == "remove_multiple" %}
+
+      {{_('Removed the following fields from resource {resource_link} in {pkg_link}').format(
+          pkg_link=dataset_link(change.pkg_id, change.title),
+          resource_link=resource_link(change.pkg_id, change.resource_id, change.resource_name),
+      )}}
+      <ul>
+        {% for item in change.key_list %}
+          {{_('{key}').format(
+            key=item
+          )|safe }}
+        {% endfor %}
+      </ul>
+
+    {% elif change.method == "change_value_with_old" %}
+
+      {{_('Changed value of field <q>{key}</q> of resource {resource_link} to <q>{new_val}</q> (previously <q>{old_val}</q>) in {pkg_link}').format(
+          pkg_link=dataset_link(change.pkg_id, change.title),
+          resource_link=resource_link(change.pkg_id, change.resource_id, change.resource_name),
+          key=change.key,
+          new_val = change.new_value,
+          old_val = change.old_value
+      )}}
+
+    {% elif change.method == "change_value_no_old" %}
+
+      {{_('Changed value of field <q>{key}</q> to <q>{new_val}</q> in resource {resource_link} in {pkg_link}').format(
+          pkg_link=dataset_link(change.pkg_id, change.title),
+          resource_link=resource_link(change.pkg_id, change.resource_id, change.resource_name),
+          key=change.key,
+          new_val = change.new_value
+      )}}
+
+    {% elif change.method == "change_value_no_new" %}
+
+      {{_('Removed the value of field <q>{key}</q> in resource {resource_link} in {pkg_link}').format(
+          pkg_link=dataset_link(change.pkg_id, change.title),
+          resource_link=resource_link(change.pkg_id, change.resource_id, change.resource_name),
+          key=change.key,
+          new_val = change.new_value
+      )}}
+    {% else %}
+
+      {{_('No fields were updated. See the metadata diff for more details.') }}
+
+    {% endif %}
+  </p>
+</li>

--- a/ckanext/unaids/theme/templates/snippets/changes/resource_extras.html
+++ b/ckanext/unaids/theme/templates/snippets/changes/resource_extras.html
@@ -11,7 +11,7 @@
       resource_id=resource_id
     )
   %}
-  <a href="{{resource_link}}">{{resource_name}}</a>
+  <a href="{{resource_url}}">{{resource_name}}</a>
 {%- endmacro %}
 
 <li>


### PR DESCRIPTION
# Problem
- The ckan `/snippets/changes/resource_extras.html` was not correctly handling ascii errors
- It's due to `resource_name` having non ascii characters and then being placed within a `str.format()`
- When we have a dataset called `Côte d'Ivoire Inputs UNAIDS Estimates 2021`, create a dataset with resources, clicking the `Changes` button on the Activity Stream would cause a server error
- A server error was reporting `'ascii' codec can't encode character u'\xf4'`

# Solution
- Allow jinja2 to render the link tags itself, rather than python string formatting inline in the template
- Remove duplicate code by creating jinja2 macros

See git diff of the changes i've made from the original ckan template here:
https://gist.github.com/Manoj-nathwani/cc31d1294eceb83654dfcefccf3cefc1/revisions

See video here showing the feature now works:
https://youtu.be/0st8QGBjno0