### PR TITLE
Adx 571 fix dataset-transfer ascii errors

### DIFF
--- a/ckanext/unaids/dataset_transfer/logic.py
+++ b/ckanext/unaids/dataset_transfer/logic.py
@@ -2,7 +2,7 @@ import logging
 
 from ckan import model
 import ckan.plugins.toolkit as toolkit
-from ckan.lib import mailer
+import ckan.lib.mailer as mailer
 from ckan.lib.base import render_jinja2
 from ckan.common import config, _
 from ckanext.unaids.dataset_transfer.model import (
@@ -104,3 +104,4 @@ def send_dataset_transfer_emails(dataset_id, recipient_org_id):
                 dataset['id']
             )
         )
+    return emails_succeeded

--- a/ckanext/unaids/dataset_transfer/logic.py
+++ b/ckanext/unaids/dataset_transfer/logic.py
@@ -71,7 +71,7 @@ def send_dataset_transfer_emails(dataset_id, recipient_org_id):
     emails_succeeded = []
     for user in users_to_email:
         try:
-            subject = dataset['title'] + ' ' + _('Dataset Transfer')
+            subject = u'{} {}'.format(dataset['title'], _('Dataset Transfer'))
             body = render_jinja2(
                 'email/dataset_transfer.txt',
                 extra_vars={

--- a/ckanext/unaids/dataset_transfer/logic.py
+++ b/ckanext/unaids/dataset_transfer/logic.py
@@ -71,7 +71,7 @@ def send_dataset_transfer_emails(dataset_id, recipient_org_id):
     emails_succeeded = []
     for user in users_to_email:
         try:
-            subject = '{} {}'.format(dataset['title'], _('Dataset Transfer'))
+            subject = dataset['title'] + ' ' + _('Dataset Transfer')
             body = render_jinja2(
                 'email/dataset_transfer.txt',
                 extra_vars={

--- a/ckanext/unaids/tests/test_dataset_transfer.py
+++ b/ckanext/unaids/tests/test_dataset_transfer.py
@@ -97,7 +97,8 @@ class TestDatasetTransfer(object):
             )
 
     @mock.patch('ckan.lib.mailer.mail_user')
-    def test_send_dataset_transfer_emails(self, mocked_mail_user, app):
+    @mock.patch('ckan.lib.mailer._mail_recipient')
+    def test_send_dataset_transfer_emails(self, mocked_mail_recipient, mocked_mail_user, app):
         user_1, user_2 = [
             factories.User()
             for x in range(2)
@@ -112,10 +113,11 @@ class TestDatasetTransfer(object):
             title=u"Côte d'Ivoire Test Dataset",
             org_to_allow_transfer_to=org_2['id']
         )
-        send_dataset_transfer_emails(
+        emails_succeeded = send_dataset_transfer_emails(
             dataset_id=dataset['id'],
             recipient_org_id=org_2['id']
         )
+        assert emails_succeeded
         mocked_mail_user.assert_called()
         emailed_user_ids = [
             x[0][0].id  # recipient_user_id
@@ -137,12 +139,11 @@ class TestDatasetTransfer(object):
             type='test-schema',
             org_to_allow_transfer_to=org_2['id']
         )
-        expected_error = r'All DatasetTransferRequest emails failed *'
-        with pytest.raises(AssertionError, match=expected_error):
-            send_dataset_transfer_emails(
-                dataset_id=dataset['id'],
-                recipient_org_id=org_2['id']
-            )
+        emails_succeeded = send_dataset_transfer_emails(
+            dataset_id=dataset['id'],
+            recipient_org_id=org_2['id']
+        )
+        assert not emails_succeeded
 
     def test_dataset_transfer_request(self, app):
 

--- a/ckanext/unaids/tests/test_dataset_transfer.py
+++ b/ckanext/unaids/tests/test_dataset_transfer.py
@@ -97,8 +97,7 @@ class TestDatasetTransfer(object):
             )
 
     @mock.patch('ckan.lib.mailer.mail_user')
-    @mock.patch('ckan.lib.mailer._mail_recipient')
-    def test_send_dataset_transfer_emails(self, mocked_mail_recipient, mocked_mail_user, app):
+    def test_send_dataset_transfer_emails(self, mocked_mail_user, app):
         user_1 = factories.User(email='user_1@example.com')
         user_2 = factories.User(email='user_2@example.com')
         org_1 = factories.Organization(user={'name': user_1['name'], 'capacity': 'admin'})

--- a/ckanext/unaids/tests/test_dataset_transfer.py
+++ b/ckanext/unaids/tests/test_dataset_transfer.py
@@ -109,7 +109,7 @@ class TestDatasetTransfer(object):
         dataset = factories.Dataset(
             owner_org=org_1['id'],
             type='test-schema',
-            name="Côte d'Ivoire Inputs UNAIDS Estimates 2021",
+            title=u"Côte d'Ivoire Test Dataset",
             org_to_allow_transfer_to=org_2['id']
         )
         send_dataset_transfer_emails(

--- a/ckanext/unaids/tests/test_dataset_transfer.py
+++ b/ckanext/unaids/tests/test_dataset_transfer.py
@@ -109,6 +109,7 @@ class TestDatasetTransfer(object):
         dataset = factories.Dataset(
             owner_org=org_1['id'],
             type='test-schema',
+            name="Côte d'Ivoire Inputs UNAIDS Estimates 2021",
             org_to_allow_transfer_to=org_2['id']
         )
         send_dataset_transfer_emails(


### PR DESCRIPTION
# Problem
Attempting to transfer a dataset with ascii characters causes an error
```
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf4' in position 1: ordinal not in range(128)
  File "flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "flask/views.py", line 89, in view
    return self.dispatch_request(*args, **kwargs)
  File "flask/views.py", line 163, in dispatch_request
    return meth(*args, **kwargs)
  File "py", line 734, in post
    pkg_dict = get_action(u'package_update')(context, data_dict)
  File "ckan/logic/__init__.py", line 473, in wrapped
    result = _action(context, data_dict, **kw)
  File "ckan/logic/action/update.py", line 330, in package_update
    item.after_update(context, data)
  File "usr/lib/ckan/extensions/ckanext-unaids/ckanext/unaids/plugin.py", line 134, in after_update
    recipient_org_id=org_to_allow_transfer_to[0]
  File "usr/lib/ckan/extensions/ckanext-unaids/ckanext/unaids/dataset_transfer/logic.py", line 74, in send_dataset_transfer_emails
    subject = '{} {}'.format(dataset['title'], _('Dataset Transfer'))
```

# Solution 
- Stop doing a `string.format()` on unicode strings
- Swap it out for a python unicode string concatenation