### PR TITLE
get-authz-token-before-file-upload

### DIFF
--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
@@ -63,7 +63,6 @@ export default function App({ lfsServer, maxResourceSize, orgId, datasetId, defa
         setUploadInProgress(true);
         getAuthToken()
             .then(authToken => {
-                console.log(authToken);
                 const client = new Client(lfsServer, authToken, ['basic']);
                 Promise.mapSeries(pendingFiles, async (file, index) => {
                     if (!file.error) {

--- a/ckanext/unaids/react/components/FileInputComponent/index.test.js
+++ b/ckanext/unaids/react/components/FileInputComponent/index.test.js
@@ -4,7 +4,7 @@ import axios from 'axios';
 import * as giftless from "giftless-client";
 
 jest.mock('axios');
-let mockedAxiosPost = undefined;
+let mockedAuthTokenRequest = undefined;
 
 function setupMocks() {
   jest.clearAllMocks();
@@ -12,9 +12,11 @@ function setupMocks() {
     default: jest.fn(),
     upload: jest.fn(() => Promise.resolve())
   }));
-  mockedAxiosPost = axios.post.mockImplementation(url => Promise.resolve({
-    data: { result: { token: 'MockedToken' } }
-  }));
+  mockedAuthTokenRequest = axios.post.mockImplementation(
+    () => Promise.resolve({
+      data: { result: { token: 'MockedToken' } }
+    })
+  );
 }
 
 async function renderAppComponent(existingResourceData) {
@@ -62,7 +64,7 @@ describe('upload a new resource', () => {
       Object.defineProperty(component, 'files', { value: [file] });
       fireEvent.drop(component);
       await screen.findByText('data.json');
-      expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
+      expect(mockedAuthTokenRequest).toHaveBeenCalledTimes(1);
       expect(screen.getByTestId('url_type')).toHaveValue('upload');
       expect(screen.getByTestId('lfs_prefix')).toHaveValue('mockedOrgId/mockedDatasetId');
       expect(screen.getByTestId('sha256')).toHaveValue('mockedSha256');

--- a/ckanext/unaids/react/components/FileInputComponent/index.test.js
+++ b/ckanext/unaids/react/components/FileInputComponent/index.test.js
@@ -4,10 +4,18 @@ import axios from 'axios';
 import * as giftless from "giftless-client";
 
 jest.mock('axios');
-giftless.Client = jest.fn(() => ({
-  default: jest.fn(),
-  upload: jest.fn(() => Promise.resolve())
-}));
+let mockedAxiosPost = undefined;
+
+function setupMocks() {
+  jest.clearAllMocks();
+  giftless.Client = jest.fn(() => ({
+    default: jest.fn(),
+    upload: jest.fn(() => Promise.resolve())
+  }));
+  mockedAxiosPost = axios.post.mockImplementation(url => Promise.resolve({
+    data: { result: { token: 'MockedToken' } }
+  }));
+}
 
 async function renderAppComponent(existingResourceData) {
   await act(async () => {
@@ -17,20 +25,14 @@ async function renderAppComponent(existingResourceData) {
       datasetId: 'mockedDatasetId',
       existingResourceData: existingResourceData
     };
-    const mockedAxiosPost = axios.post.mockImplementation(() =>
-      Promise.resolve({
-        data: { result: { token: 'MockedToken' } }
-      })
-    );
     render(<App {...mockedAppProps} />);
-    await new Promise(resolve => setTimeout(resolve, 20));
-    expect(mockedAxiosPost).toHaveBeenCalled();
   })
 };
 
 describe('upload a new resource', () => {
 
   beforeEach(async () => {
+    setupMocks();
     await renderAppComponent({
       urlType: null,
       url: null,
@@ -60,6 +62,7 @@ describe('upload a new resource', () => {
       Object.defineProperty(component, 'files', { value: [file] });
       fireEvent.drop(component);
       await screen.findByText('data.json');
+      expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
       expect(screen.getByTestId('url_type')).toHaveValue('upload');
       expect(screen.getByTestId('lfs_prefix')).toHaveValue('mockedOrgId/mockedDatasetId');
       expect(screen.getByTestId('sha256')).toHaveValue('mockedSha256');

--- a/ckanext/unaids/react/components/FileInputComponent/src/App.js
+++ b/ckanext/unaids/react/components/FileInputComponent/src/App.js
@@ -9,12 +9,11 @@ import HiddenFormInputs from './HiddenFormInputs';
 export default function App({ maxResourceSize, lfsServer, orgId, datasetId, existingResourceData }) {
 
     const defaultUploadProgress = { loaded: 0, total: 0 };
-    const [authToken, setAuthToken] = useState();
     const [uploadMode, setUploadMode] = useState();
     const [uploadProgress, setUploadProgress] = useState(defaultUploadProgress);
     const [uploadfileName, setUploadFileName] = useState();
     const [linkUrl, setLinkUrl] = useState();
-    const [hiddenInputs, _setHiddenInputs] = useState();
+    const [hiddenInputs, _setHiddenInputs] = useState({});
     const [uploadError, setUploadError] = useState(false);
 
     const setHiddenInputs = (newUploadMode, metadata) => {
@@ -52,16 +51,6 @@ export default function App({ maxResourceSize, lfsServer, orgId, datasetId, exis
     }
 
     useEffect(() => {
-        axios.post(
-            '/api/3/action/authz_authorize',
-            { scopes: `obj:ckan/${datasetId}/*:write` },
-            { withCredentials: true }
-        )
-            .then(res => setAuthToken(res.data.result.token))
-            .catch(error => {
-                console.log(`authz_authorize error: ${error}`);
-                setAuthToken('error')
-            })
         const data = existingResourceData;
         if (data.urlType === 'upload') {
             // resource already has a file
@@ -84,12 +73,6 @@ export default function App({ maxResourceSize, lfsServer, orgId, datasetId, exis
             setHiddenInputs(null, {});
         };
     }, []);
-
-    if (!authToken) {
-        return ckan.i18n._('Loading');
-    } else if (authToken === 'error') {
-        return ckan.i18n._('Authentication Error: Failed to load file uploader');
-    }
 
     if (uploadError) return (
         <div className="alert alert-danger">
@@ -125,7 +108,7 @@ export default function App({ maxResourceSize, lfsServer, orgId, datasetId, exis
             [null, 'file'].includes(uploadMode)
                 ? <FileUploader {...{
                     maxResourceSize, lfsServer, orgId, datasetId,
-                    authToken, setUploadProgress, setUploadFileName,
+                    setUploadProgress, setUploadFileName,
                     setHiddenInputs, setUploadError
                 }} />
                 : <UrlUploader {...{ linkUrl, resetComponent }} />


### PR DESCRIPTION
https://fjelltopp.atlassian.net/jira/software/projects/ADX/boards/4?selectedIssue=ADX-647

# Problem
- We were requesting the authz token on page load
- This meant if you open the file upload page, leave it open for 30mins, the token would expire when you finally got around to selecting a file to upload

# Solution
- We now request a new auth token at the time of actually uploading something