### PR TITLE
Adx 648 request authz token before each bulked file upload

### DIFF
--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/index.test.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/index.test.js
@@ -53,36 +53,38 @@ const selectFilesToUpload = async (elementTestId, files) => {
     fireEvent.drop(component);
   });
 }
-const uploadFilesAndCreateResources = async successfulFileUploads => {
+const uploadFilesAndCreateResources = async (validFileUploads, invalidFileUpload) => {
   fireEvent.click(screen.getByTestId('UploadFilesButton'));
   await screen.findByText('Uploads Complete');
   const filesUploaded = await screen.findAllByText('Uploaded');
-  expect(filesUploaded).toHaveLength(successfulFileUploads.length);
+  expect(filesUploaded).toHaveLength(validFileUploads.length);
+  const requestsForAuthToken = validFileUploads.length + invalidFileUpload.length;
+  const requestsForUploadFile = requestsForAuthToken - invalidFileUpload.length;
   expect(mockedAxiosPost).toHaveBeenCalledTimes(
-    // 2 requests as we want to getAuthToken and then uploadFile
-    successfulFileUploads.length * 2
+    requestsForAuthToken + requestsForUploadFile
   );
 }
 
 const testSuccessfulUpload = async elementTestId => {
-  const files = [
+  const validFiles = [
     new File(['file'], 'file_1.json'),
     new File(['file'], 'file_2.json'),
   ];
-  await selectFilesToUpload(elementTestId, files);
+  const invalidFiles = [];
+  await selectFilesToUpload(elementTestId, validFiles);
   await screen.findByText('file_1.json');
   await screen.findByText('file_2.json');
-  await uploadFilesAndCreateResources(files);
+  await uploadFilesAndCreateResources(validFiles, invalidFiles);
 };
 const testUploadWithFileTooLarge = async elementTestId => {
-  const files = [
-    new File(['file'], 'file_1.json'),
-    new File([new ArrayBuffer(maxResourceSize * 10000000)], 'file_2.json'),
-  ];
-  await selectFilesToUpload(elementTestId, files);
+  const validFile = new File(['file'], 'file_1.json');
+  const invalidFile = new File(
+    [new ArrayBuffer(maxResourceSize * 10000000)], 'file_2.json'
+  );
+  await selectFilesToUpload(elementTestId, [validFile, invalidFile]);
   await screen.findByText('file_1.json');
   await screen.findByText('file_2.json');
-  await uploadFilesAndCreateResources([files[0]]);
+  await uploadFilesAndCreateResources([validFile], [invalidFile]);
 };
 
 describe('test without network issues', () => {

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/index.test.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/index.test.js
@@ -59,7 +59,8 @@ const uploadFilesAndCreateResources = async successfulFileUploads => {
   const filesUploaded = await screen.findAllByText('Uploaded');
   expect(filesUploaded).toHaveLength(successfulFileUploads.length);
   expect(mockedAxiosPost).toHaveBeenCalledTimes(
-    ['get authToken', ...successfulFileUploads].length
+    // 2 requests as we want to getAuthToken and then uploadFile
+    successfulFileUploads.length * 2
   );
 }
 

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
@@ -32,8 +32,12 @@ export default function App({ lfsServer, maxResourceSize, orgId, datasetId, defa
             '/api/3/action/authz_authorize',
             { scopes: `obj:ckan/${datasetId}/*:write` },
             { withCredentials: true }
-        ).then(res => res.data.result.token)
-    const uploadFile = (client, localFile, setFileProgress) =>
+        )
+            .then(res => res.data.result.token)
+            .catch(error => handleNetworkError(
+                ckan.i18n._('Authorisation Error'), error
+            ))
+    const uploadFile = (client, index, localFile, setFileProgress) =>
         client.upload(
             localFile, orgId, datasetId,
             ({ loaded, total }) =>
@@ -61,25 +65,20 @@ export default function App({ lfsServer, maxResourceSize, orgId, datasetId, defa
 
     const uploadFiles = () => {
         setUploadInProgress(true);
-        getAuthToken()
-            .then(authToken => {
-                console.log(authToken);
-                const client = new Client(lfsServer, authToken, ['basic']);
-                Promise.mapSeries(pendingFiles, async (file, index) => {
-                    if (!file.error) {
-                        const localFile = data.open(file);
-                        setFileProgress(index, 0, 100);
-                        await uploadFile(client, localFile, setFileProgress);
-                        await createResource(localFile);
-                        setFileProgress(index, 100, 100);
-                        setUploadInProgress(false);
-                        setUploadsComplete(true);
-                    }
-                })
-            })
-            .catch(error => handleNetworkError(
-                ckan.i18n._('Authorisation Error'), error
-            ))
+        Promise.mapSeries(pendingFiles, async (file, index) => {
+            if (networkError) return;
+            const authToken = await getAuthToken();
+            const client = new Client(lfsServer, authToken, ['basic']);
+            if (!file.error) {
+                const localFile = data.open(file);
+                setFileProgress(index, 0, 100);
+                await uploadFile(client, index, localFile, setFileProgress);
+                await createResource(localFile);
+                setFileProgress(index, 100, 100);
+                setUploadInProgress(false);
+                setUploadsComplete(true);
+            }
+        })
     }
 
     function PendingFilesTable() {


### PR DESCRIPTION
https://fjelltopp.atlassian.net/jira/software/projects/ADX/boards/4?selectedIssue=ADX-647

# Problem
- We were requesting the authz token before uploading any files, then recycling the same token for every file upload
- The issue is that if a user uploads 20 files, each taking 2mins to upload, then the last few files would fail to upload as the auth token would have expired

# Solution
- We now request a new auth token before uploading each file