### PR TITLE
fix-uploads-completed-timing

### DIFF
--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
@@ -75,10 +75,8 @@ export default function App({ lfsServer, maxResourceSize, orgId, datasetId, defa
                 await uploadFile(client, index, localFile, setFileProgress);
                 await createResource(localFile);
                 setFileProgress(index, 100, 100);
-                setUploadInProgress(false);
-                setUploadsComplete(true);
             }
-        })
+        }).then(() => setUploadsComplete(true));
     }
 
     function PendingFilesTable() {


### PR DESCRIPTION
# Before
Before all files have finished uploading, we wrongly state Uploads Complete

![image](https://user-images.githubusercontent.com/2634482/115047768-bb700900-9ed0-11eb-8268-3709fadf0f45.png)


# After
Now we correctly show it's still uploading

![image](https://user-images.githubusercontent.com/2634482/115047738-b6ab5500-9ed0-11eb-9438-1f048b328543.png)

Then once completed, it says Uploads Complete

![image](https://user-images.githubusercontent.com/2634482/115047902-e4909980-9ed0-11eb-968e-6cf187a657cb.png)
