### PR TITLE
add delete resource button to dataset_show

### DIFF
--- a/ckanext/unaids/theme/templates/package/snippets/resource_item.html
+++ b/ckanext/unaids/theme/templates/package/snippets/resource_item.html
@@ -22,10 +22,10 @@
 
 {% block resource_item_explore_links %}
   {{ super() }}
-  {% if can_edit %}
+  {% if h.check_access('resource_delete', {'id': res.id})  %}
     <li>
-      <a href="{{ h.url_for(pkg.type ~ '_resource.delete', id=pkg.name, resource_id=res.id) }}">
-        <i class="fa fa-trash"></i>
+      <a href="{% url_for pkg.type ~ '_resource.delete', id=pkg.name, resource_id=res.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this resource?') }}">
+        <i class="fa fa-times"></i>
         {{ _('Delete') }}
       </a>
     </li>

--- a/ckanext/unaids/theme/templates/package/snippets/resource_item.html
+++ b/ckanext/unaids/theme/templates/package/snippets/resource_item.html
@@ -1,4 +1,5 @@
 {% ckan_extends %}
+
 {% block resource_item_title %}
   <div class="resource-title">
     {{ super() }}
@@ -16,5 +17,17 @@
     <p class="description" title="{{ h.render_datetime(res.last_modified, with_hours=True) }}">
       {{ _('Last modified') + ": "}}{{ h.time_ago_from_timestamp(res.last_modified) }}
     </p>
+  {% endif %}
+{% endblock %}
+
+{% block resource_item_explore_links %}
+  {{ super() }}
+  {% if can_edit %}
+    <li>
+      <a href="{{ h.url_for(pkg.type ~ '_resource.delete', id=pkg.name, resource_id=res.id) }}">
+        <i class="fa fa-trash"></i>
+        {{ _('Delete') }}
+      </a>
+    </li>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Problem
The `Delete` button has gone missing on the dataset_show page

![image](https://user-images.githubusercontent.com/2634482/115403946-c71b4280-a1e4-11eb-96fe-3ab89621e9bc.png)

## Solution
![image](https://user-images.githubusercontent.com/2634482/115404037-dd290300-a1e4-11eb-8829-4b309be066bc.png)

Originally `ckanext-file_uploader_ui` was adding the `Delete` button to `resource_item_explore_links`

I've copied the `<li>` from here: https://github.com/fjelltopp/ckanext-file_uploader_ui/blob/development/ckanext/file_uploader_ui/templates/package/snippets/resource_item.html#L37-L44