### PR TITLE
Adx 641 giftless ckan actions

### DIFF
--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -172,8 +172,21 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
             # scope = extstorage_helpers.resource_authz_scope(
             #     package_name, org_name=org_name, actions='write', resource_id=resource_id)
             scope = 'obj:ckan/{}/*:write '.format(package_name)
+            
             print('---> {}'.format(scope))
+            
             authz_result = authorize(context, {"scopes": [scope]})
+
+            print('~'*50)
+            print('context')
+            for key in context.keys():
+                print('{} = {}'.format(key, context[key]))
+            print('~'*50)
+            print('authz_result')
+            for key in authz_result.keys():
+                print('{} = {}'.format(key, authz_result[key]))
+            print('~'*50)
+
             if not authz_result or not authz_result.get('token', False):
                 raise RuntimeError("Failed to get authorization token for LFS server")
             if len(authz_result['granted_scopes']) == 0:

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -149,51 +149,51 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
                 )
 
     # IResourceController
-    def before_create(self, context, data_dict):
-        print('~'*50)
-        print('before_create')
-        print(data_dict)
-        print('~'*50)
-        return data_dict
+    # def before_create(self, context, data_dict):
+    #     print('~'*50)
+    #     print('before_create')
+    #     print(data_dict)
+    #     print('~'*50)
+    #     return data_dict
 
-    def before_update(self, context, current, data_dict):
-        print('~'*50)
-        print('before_update')
-        print('data_dict')
-        print(data_dict)
-        print('current')
-        print(current)
+    # def before_update(self, context, current, data_dict):
+    #     print('~'*50)
+    #     print('before_update')
+    #     print('data_dict')
+    #     print(data_dict)
+    #     print('current')
+    #     print(current)
 
-        attached_file = data_dict.get('upload', None)
-        if attached_file:
-            if type(attached_file) == FlaskFileStorage:
-                print('~'*50)
-                print(attached_file.headers)
-                lfs_client = LfsClient(
-                    lfs_server_url=extstorage_helpers.server_url(),
-                    auth_token='eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZXMiOiJvYmo6Y2thbi9hbGdlcmlhLWlucHV0cy11bmFpZHMtZXN0aW1hdGVzLTIwMjEvKjp3cml0ZSIsIm5hbWUiOiJBZG1pbiIsImlzcyI6Imh0dHA6Ly9kZXYtYWRyIiwiZXhwIjoxNjE4MzI3MzA1LCJuYmYiOjE2MTgzMjY0MDUsInN1YiI6ImFkbWluIn0.IfZB77nZAz69gs3xIUGuCchw6JHCCmBSt_RovG7NBKw-ld6tcGJG1qPdBAX9KFr-cNtxrfxDLpxoSuG5_yB9luIZy7pdpzSYD653C2xRdBQmJAcV9mfKZX_FMXHponDoQx7JUlWphdUUFDdu5yibg_ZSG3s7g3RmUTXhHxOkL0Cmn_OhCNKg3mL7ikqw3-NGn01Pu-b6R7dq8-ypv-Stmd1TMTjRmVN62_om5MNSYqopG8zxpD5Qeee1nV8--GN24sDk8i_9soN4aMU3Qq8c9vPfEaxvM4k-CFhdCbV5J_CFXZcip_Kj8yaM0L8vxFXVDa0A8i2T9_A3RXyRJf6s1w',
-                    transfer_adapters=['basic']
-                )
-                dataset = get_action('package_show')(context, {'id': current['package_id']})
-                lfs_prefix = extstorage_helpers.resource_storage_prefix(current['package_id'])
-                uploaded_file = lfs_client.upload(
-                    file_obj=attached_file,
-                    organization=lfs_prefix.split('/')[0],
-                    repo=dataset['name']
-                )
-                print(uploaded_file)
-                data_dict.pop('upload', None)
-                data_dict.update({
-                    'url_type': 'upload',
-                    'name': attached_file.filename,
-                    'sha256': uploaded_file['oid'],
-                    'size': uploaded_file['size'],
-                    'url': attached_file.filename,
-                    'lfs_prefix': lfs_prefix
-                })
+    #     attached_file = data_dict.get('upload', None)
+    #     if attached_file:
+    #         if type(attached_file) == FlaskFileStorage:
+    #             print('~'*50)
+    #             print(attached_file.headers)
+    #             lfs_client = LfsClient(
+    #                 lfs_server_url=extstorage_helpers.server_url(),
+    #                 auth_token='eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZXMiOiJvYmo6Y2thbi9hbGdlcmlhLWlucHV0cy11bmFpZHMtZXN0aW1hdGVzLTIwMjEvKjp3cml0ZSIsIm5hbWUiOiJBZG1pbiIsImlzcyI6Imh0dHA6Ly9kZXYtYWRyIiwiZXhwIjoxNjE4MzI3MzA1LCJuYmYiOjE2MTgzMjY0MDUsInN1YiI6ImFkbWluIn0.IfZB77nZAz69gs3xIUGuCchw6JHCCmBSt_RovG7NBKw-ld6tcGJG1qPdBAX9KFr-cNtxrfxDLpxoSuG5_yB9luIZy7pdpzSYD653C2xRdBQmJAcV9mfKZX_FMXHponDoQx7JUlWphdUUFDdu5yibg_ZSG3s7g3RmUTXhHxOkL0Cmn_OhCNKg3mL7ikqw3-NGn01Pu-b6R7dq8-ypv-Stmd1TMTjRmVN62_om5MNSYqopG8zxpD5Qeee1nV8--GN24sDk8i_9soN4aMU3Qq8c9vPfEaxvM4k-CFhdCbV5J_CFXZcip_Kj8yaM0L8vxFXVDa0A8i2T9_A3RXyRJf6s1w',
+    #                 transfer_adapters=['basic']
+    #             )
+    #             dataset = get_action('package_show')(context, {'id': current['package_id']})
+    #             lfs_prefix = extstorage_helpers.resource_storage_prefix(current['package_id'])
+    #             uploaded_file = lfs_client.upload(
+    #                 file_obj=attached_file,
+    #                 organization=lfs_prefix.split('/')[0],
+    #                 repo=dataset['name']
+    #             )
+    #             print(uploaded_file)
+    #             data_dict.pop('upload', None)
+    #             data_dict.update({
+    #                 'url_type': 'upload',
+    #                 'name': attached_file.filename,
+    #                 'sha256': uploaded_file['oid'],
+    #                 'size': uploaded_file['size'],
+    #                 'url': attached_file.filename,
+    #                 'lfs_prefix': lfs_prefix
+    #             })
 
-                print('~'*50)
-                return data_dict
+    #             print('~'*50)
+    #             return data_dict
 
 
 class UNAIDSReclineView(ReclineViewBase):

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -1,11 +1,14 @@
 import ckan.plugins as p
 import logging
 from collections import OrderedDict
+from giftless_client import LfsClient
 import ckan.model.license as core_licenses
 import ckan.model.package as package
 import ckan.plugins.toolkit as toolkit
 import ckan.lib.uploader as uploader
 from ckan.lib.plugins import DefaultTranslation
+from ckan.logic import get_action
+from werkzeug.datastructures import FileStorage as FlaskFileStorage
 from ckanext.unaids.validators import (
     if_empty_guess_format,
     organization_id_exists_validator
@@ -56,6 +59,7 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
     p.implements(p.ITemplateHelpers)
     p.implements(p.IAuthFunctions)
     p.implements(p.IPackageController, inherit=True)
+    p.implements(p.IResourceController, inherit=True)
     p.implements(p.IValidators)
     p.implements(p.IActions)
     p.implements(IDataValidation)
@@ -143,6 +147,53 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
                     dataset_id=pkg_dict['id'],
                     recipient_org_id=org_to_allow_transfer_to[0]
                 )
+
+    # IResourceController
+    def before_create(self, context, data_dict):
+        print('~'*50)
+        print('before_create')
+        print(data_dict)
+        print('~'*50)
+        return data_dict
+
+    def before_update(self, context, current, data_dict):
+        print('~'*50)
+        print('before_update')
+        print('data_dict')
+        print(data_dict)
+        print('current')
+        print(current)
+
+        attached_file = data_dict.get('upload', None)
+        if attached_file:
+            if type(attached_file) == FlaskFileStorage:
+                print('~'*50)
+                print(attached_file.headers)
+                lfs_client = LfsClient(
+                    lfs_server_url=extstorage_helpers.server_url(),
+                    auth_token='eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZXMiOiJvYmo6Y2thbi9hbGdlcmlhLWlucHV0cy11bmFpZHMtZXN0aW1hdGVzLTIwMjEvKjp3cml0ZSIsIm5hbWUiOiJBZG1pbiIsImlzcyI6Imh0dHA6Ly9kZXYtYWRyIiwiZXhwIjoxNjE4MzI3MzA1LCJuYmYiOjE2MTgzMjY0MDUsInN1YiI6ImFkbWluIn0.IfZB77nZAz69gs3xIUGuCchw6JHCCmBSt_RovG7NBKw-ld6tcGJG1qPdBAX9KFr-cNtxrfxDLpxoSuG5_yB9luIZy7pdpzSYD653C2xRdBQmJAcV9mfKZX_FMXHponDoQx7JUlWphdUUFDdu5yibg_ZSG3s7g3RmUTXhHxOkL0Cmn_OhCNKg3mL7ikqw3-NGn01Pu-b6R7dq8-ypv-Stmd1TMTjRmVN62_om5MNSYqopG8zxpD5Qeee1nV8--GN24sDk8i_9soN4aMU3Qq8c9vPfEaxvM4k-CFhdCbV5J_CFXZcip_Kj8yaM0L8vxFXVDa0A8i2T9_A3RXyRJf6s1w',
+                    transfer_adapters=['basic']
+                )
+                dataset = get_action('package_show')(context, {'id': current['package_id']})
+                lfs_prefix = extstorage_helpers.resource_storage_prefix(current['package_id'])
+                uploaded_file = lfs_client.upload(
+                    file_obj=attached_file,
+                    organization=lfs_prefix.split('/')[0],
+                    repo=dataset['name']
+                )
+                print(uploaded_file)
+                data_dict.pop('upload', None)
+                data_dict.update({
+                    'url_type': 'upload',
+                    'name': attached_file.filename,
+                    'sha256': uploaded_file['oid'],
+                    'size': uploaded_file['size'],
+                    'url': attached_file.filename,
+                    'lfs_prefix': lfs_prefix
+                })
+
+                print('~'*50)
+                return data_dict
 
 
 class UNAIDSReclineView(ReclineViewBase):

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -212,7 +212,7 @@ def _giftless_upload(context, resource, current=None):
             dataset = get_action('package_show')(
                 context, {'id': dataset_id})
             org_name = dataset.get('organization', {}).get('name')
-            authz_token = get_upload_authz_token(
+            authz_token = _get_upload_authz_token(
                 context,
                 dataset_id,
                 org_name
@@ -238,7 +238,10 @@ def _giftless_upload(context, resource, current=None):
             })
 
 
-def get_upload_authz_token(context, dataset_id, org_name):
+def _get_upload_authz_token(context, dataset_id, org_name):
+    # this should be done with toolkit.get_action('authz_authorize')
+    # but authz_authorize ignored user information passed inside `context`
+    # more: https://github.com/datopian/ckanext-authz-service/issues/24
     scope = 'obj:{}/{}/*:write'.format(org_name, dataset_id)
     user = model.User.by_name(context['user'])
     user_apikey = user.apikey

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -152,15 +152,15 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
                 )
 
     # IResourceController
-    def before_create(self, context, data_dict):
-        if _data_dict_is_resource(data_dict):
-            _giftless_upload(context, data_dict)
-        return data_dict
+    def before_create(self, context, resource):
+        if _data_dict_is_resource(resource):
+            _giftless_upload(context, resource)
+        return resource
 
-    def before_update(self, context, current, data_dict):
-        if _data_dict_is_resource(data_dict):
-            _giftless_upload(context, data_dict, current=current)
-        return data_dict
+    def before_update(self, context, current, resource):
+        if _data_dict_is_resource(resource):
+            _giftless_upload(context, resource, current=current)
+        return resource
 
 
 class UNAIDSReclineView(ReclineViewBase):
@@ -202,11 +202,11 @@ def _data_dict_is_resource(data_dict):
             or data_dict.get(u'type') == u'dataset')
 
 
-def _giftless_upload(context, data_dict, current=None):
-    attached_file = data_dict.get('upload', None)
+def _giftless_upload(context, resource, current=None):
+    attached_file = resource.pop('upload', None)
     if attached_file:
         if type(attached_file) == FlaskFileStorage:
-            dataset_id = data_dict.get('package_id')
+            dataset_id = resource.get('package_id')
             if not dataset_id:
                 dataset_id = current['package_id']
             dataset = get_action('package_show')(
@@ -228,11 +228,9 @@ def _giftless_upload(context, data_dict, current=None):
                 repo=dataset_id
             )
 
-            data_dict.pop('upload', None)
             lfs_prefix = extstorage_helpers.resource_storage_prefix(dataset_id)
-            data_dict.update({
+            resource.update({
                 'url_type': 'upload',
-                'name': attached_file.filename,
                 'sha256': uploaded_file['oid'],
                 'size': uploaded_file['size'],
                 'url': attached_file.filename,

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -238,8 +238,8 @@ def _giftless_upload(context, resource, current=None):
             })
 
 
-def get_upload_authz_token(context, dataset_name, org_name):
-    scope = 'obj:{}/{}/*:write'.format(org_name, dataset_name)
+def get_upload_authz_token(context, dataset_id, org_name):
+    scope = 'obj:{}/{}/*:write'.format(org_name, dataset_id)
     user = model.User.by_name(context['user'])
     user_apikey = user.apikey
     site_url = config.get('ckan.site_url')

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -228,7 +228,7 @@ def _giftless_upload(context, resource, current=None):
                 repo=dataset_id
             )
 
-            lfs_prefix = extstorage_helpers.resource_storage_prefix(dataset_id)
+            lfs_prefix = extstorage_helpers.resource_storage_prefix(dataset['name'])
             resource.update({
                 'url_type': 'upload',
                 'sha256': uploaded_file['oid'],

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -8,7 +8,6 @@ import ckan.model.package as package
 import ckan.plugins.toolkit as toolkit
 import ckan.lib.uploader as uploader
 from ckan import model
-from ckan.common import config
 from ckan.lib.plugins import DefaultTranslation
 from ckan.logic import get_action
 from werkzeug.datastructures import FileStorage as FlaskFileStorage
@@ -245,16 +244,19 @@ def _get_upload_authz_token(context, dataset_id, org_name):
     scope = 'obj:{}/{}/*:write'.format(org_name, dataset_id)
     user = model.User.by_name(context['user'])
     user_apikey = user.apikey
-    site_url = config.get('ckan.site_url')
-    auth_path = '/api/3/action/authz_authorize'
+    auth_url = toolkit.url_for(
+        'api.action',
+        ver=3,
+        logic_function='authz_authorize',
+        _external=True
+    )
     payload = {
         'scopes': scope
     }
     headers = {
         'Authorization': str(user_apikey)
     }
-    url = "{}{}".format(site_url, auth_path)
-    auth_r = requests.post(url, headers=headers, data=payload)
+    auth_r = requests.post(auth_url, headers=headers, data=payload)
     authz_result = auth_r.json()['result']
     log.error(authz_result)
     if not authz_result or not authz_result.get('token', False):

--- a/ckanext/unaids/tests/test_giftless_backend.py
+++ b/ckanext/unaids/tests/test_giftless_backend.py
@@ -1,11 +1,16 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+from six import StringIO
+
 import ckan.tests.factories as factories
+from ckan.plugins import toolkit
+from ckan import model
 from ckan.tests.helpers import call_action
+from werkzeug.datastructures import FileStorage as FlaskFileStorage
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'unaids')
+@pytest.mark.ckan_config('ckan.plugins', 'unaids authz_service external_storage')
 @pytest.mark.usefixtures('with_plugins')
 @pytest.mark.usefixtures('clean_db')
 @pytest.mark.usefixtures('create_with_upload')
@@ -13,13 +18,35 @@ class TestGiftlessBackend(object):
 
     def test_resource_update(self, create_with_upload):
         user = factories.User()
-        dataset = factories.Dataset(user=user)
-        file_name = 'file.csv'
-        resource = create_with_upload(
-            data='hello,world',
-            filename=file_name,
-            package_id=dataset['id']
+        org = factories.Organization(
+            users=[
+                {'name': user['name'], 'capacity': 'admin'},
+            ]
+        )
+        dataset = factories.Dataset(user=user, owner_org=org['id'])
+        filename = 'file.csv'
+        csv_stream = StringIO(b'col1,col2\ntest,file')
+        resource = {
+            "name": 'Test',
+            "description": "Test resource",
+            "url_type": "upload",
+            ### old way of passing the file
+            "upload": FlaskFileStorage(
+                stream=csv_stream,
+                content_type="text/csv",
+                filename=filename
+            ),
+            "package_id": dataset["id"]
+        }
+        context = {
+            'model': model,
+            'user': user['name']
+        }
+
+        result = toolkit.get_action('resource_create')(
+            context,
+            resource
         )
         assert 'sha256' in resource
         assert 'lfs_prefix' in resource
-        assert resource.get('name', None) == file_name
+        assert resource.get('name', None) == filename

--- a/ckanext/unaids/tests/test_giftless_backend.py
+++ b/ckanext/unaids/tests/test_giftless_backend.py
@@ -12,15 +12,14 @@ from ckan.tests.helpers import call_action
 class TestGiftlessBackend(object):
 
     def test_resource_update(self, create_with_upload):
-        dataset = factories.Dataset()
+        user = factories.User()
+        dataset = factories.Dataset(user=user)
         file_name = 'file.csv'
         resource = create_with_upload(
             data='hello,world',
             filename=file_name,
             package_id=dataset['id']
         )
-        assert 'upload' not in resource, \
-            'The resource should no longer have a file attached to it'
         assert 'sha256' in resource
         assert 'lfs_prefix' in resource
         assert resource.get('name', None) == file_name

--- a/ckanext/unaids/tests/test_giftless_backend.py
+++ b/ckanext/unaids/tests/test_giftless_backend.py
@@ -6,17 +6,16 @@ from six import StringIO
 import ckan.tests.factories as factories
 from ckan.plugins import toolkit
 from ckan import model
-from ckan.tests.helpers import call_action
 from werkzeug.datastructures import FileStorage as FlaskFileStorage
 
 
 @pytest.mark.ckan_config('ckan.plugins', 'unaids authz_service external_storage')
 @pytest.mark.usefixtures('with_plugins')
 @pytest.mark.usefixtures('clean_db')
-# @pytest.mark.usefixtures('create_with_upload')
 class TestGiftlessBackend(object):
 
-    @pytest.mark.skip("doesn't work as long as HTTP auth is used. Wait for https://github.com/datopian/ckanext-authz-service/issues/24")
+    @pytest.mark.skip("doesn't work as long as HTTP auth is used."
+                      " Wait for https://github.com/datopian/ckanext-authz-service/issues/24")
     def test_giftless_resource_create(self):
         user = factories.User()
         org = factories.Organization(
@@ -43,7 +42,7 @@ class TestGiftlessBackend(object):
             'user': user['name']
         }
 
-        result = toolkit.get_action('resource_create')(
+        toolkit.get_action('resource_create')(
             context,
             resource
         )

--- a/ckanext/unaids/tests/test_giftless_backend.py
+++ b/ckanext/unaids/tests/test_giftless_backend.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import ckan.tests.factories as factories
+from ckan.tests.helpers import call_action
+
+
+@pytest.mark.ckan_config('ckan.plugins', 'unaids')
+@pytest.mark.usefixtures('with_plugins')
+@pytest.mark.usefixtures('clean_db')
+@pytest.mark.usefixtures('create_with_upload')
+class TestGiftlessBackend(object):
+
+    def test_resource_update(self, create_with_upload):
+        dataset = factories.Dataset()
+        file_name = 'file.csv'
+        resource = create_with_upload(
+            data='hello,world',
+            filename=file_name,
+            package_id=dataset['id']
+        )
+        assert 'upload' not in resource, \
+            'The resource should no longer have a file attached to it'
+        assert 'sha256' in resource
+        assert 'lfs_prefix' in resource
+        assert resource.get('name', None) == file_name

--- a/ckanext/unaids/tests/test_giftless_backend.py
+++ b/ckanext/unaids/tests/test_giftless_backend.py
@@ -13,10 +13,11 @@ from werkzeug.datastructures import FileStorage as FlaskFileStorage
 @pytest.mark.ckan_config('ckan.plugins', 'unaids authz_service external_storage')
 @pytest.mark.usefixtures('with_plugins')
 @pytest.mark.usefixtures('clean_db')
-@pytest.mark.usefixtures('create_with_upload')
+# @pytest.mark.usefixtures('create_with_upload')
 class TestGiftlessBackend(object):
 
-    def test_resource_update(self, create_with_upload):
+    @pytest.mark.skip("doesn't work as long as HTTP auth is used. Wait for https://github.com/datopian/ckanext-authz-service/issues/24")
+    def test_giftless_resource_create(self):
         user = factories.User()
         org = factories.Organization(
             users=[
@@ -30,7 +31,6 @@ class TestGiftlessBackend(object):
             "name": 'Test',
             "description": "Test resource",
             "url_type": "upload",
-            ### old way of passing the file
             "upload": FlaskFileStorage(
                 stream=csv_stream,
                 content_type="text/csv",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+giftless-client==0.1.1

--- a/test.ini
+++ b/test.ini
@@ -14,9 +14,8 @@ ckanext.validation.schema_directory = /ckanext/unaids/tests/test_schemas
 scheming.presets = ckanext.unaids:presets.json
                    ckanext.scheming:presets.json
 scheming.dataset_schemas = ckanext.unaids.tests.test_scheming_schemas:test_schema.json
-# Insert any custom config settings to be used when running your extension's
-# tests here.
-
+ckanext.authz_service.jwt_algorithm=none
+ckanext.authz_service.jwt_private_key=
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
By implementing IResourceController interface this PR enhances resource create/update decorator which upload file to giftless storage and updates blob storage fields in the resource dict.

Notes:
1. Due to an issue in ckanext_blob_storage & ckanext_authz service this PR uses HTTP to get giftless auth token. The root cause issue should be resolved soon with: https://github.com/datopian/ckanext-authz-service/pull/25
2. This PR lacks integration pytests as it'll be much easier to write them once 1. is resolved