### PR TITLE
Nicer loading for single file uploader

### DIFF
--- a/ckanext/unaids/theme/templates/scheming/form_snippets/upload.html
+++ b/ckanext/unaids/theme/templates/scheming/form_snippets/upload.html
@@ -11,6 +11,14 @@
     data-existingSha256="{{ data.sha256 if data else '' }}"
     data-existingFileName="{{ h.extstorage_resource_filename(data) if data else '' }}"
     data-existingSize="{{ data.size if data else '' }}"
-></div>
+>       
+    {% if data.url %}
+        <h3 class="text-muted"><i class="fa fa-spinner fa-spin"></i> {{ _('Loading') }}</h3>
+    {% else %}
+        <div class="dropzone text-muted">
+            <h3><i class="fa fa-spinner fa-spin"></i> {{ _('Loading') }}</h3>
+        </div>        
+    {% endif %}
+</div>
 
 {% asset 'ckanext-unaids/FileInputComponentScripts' %}


### PR DESCRIPTION
# Problem
- The single file uploader takes a few seconds to load as it's waiting for ckan.i18n to load into the browser
- It's confusing to users as they expect everything to be loaded onto the page immediately.

# Solution
- Added a simple loading banner as a placeholder until the react component is rendered

Uploading a new file/url
|loading |rendered|
--- | --- 
|![image](https://user-images.githubusercontent.com/2634482/118276400-85b64400-b4bf-11eb-9ba0-5fc77abace96.png)|![image](https://user-images.githubusercontent.com/2634482/118276489-a088b880-b4bf-11eb-9a15-7895effd4b70.png)|

Editing an existing file/url
|loading |rendered|
--- | --- 
|![image](https://user-images.githubusercontent.com/2634482/118276821-fc534180-b4bf-11eb-8626-8039812a7f8b.png)|![image](https://user-images.githubusercontent.com/2634482/118276934-2442a500-b4c0-11eb-8dc9-516fcd992a2a.png)

