### PR TITLE
Adx 658 email user search

### DIFF
--- a/ckanext/unaids/i18n/extra_translations.py
+++ b/ckanext/unaids/i18n/extra_translations.py
@@ -48,5 +48,5 @@ extra_translations = [
     _('A spectrum file used to run the Naomi model'),
     _('License definitions and additional information can be found at http://opendefinition.org/'),
     _('Reorder resources'),
-
+    _('Organisation Name / ID')
 ]

--- a/ckanext/unaids/presets.json
+++ b/ckanext/unaids/presets.json
@@ -43,6 +43,8 @@
             "label": "Public"
           }
         ],
+        "placeholder_users": "Username / Email",
+        "placeholder_orgs": "Organisation Name / ID",
         "form_attrs_users": {
           "data-module": "autocomplete-without-creating-new-options",
           "data-module-tags": "",

--- a/ckanext/unaids/theme/templates/organization/member_new.html
+++ b/ckanext/unaids/theme/templates/organization/member_new.html
@@ -22,7 +22,7 @@
             <input id="username" name="username" type="text" value="{{ user.name }}"
             disabled="True" class="form-control">
           {% else %}
-              <input id="username" type="text" name="username" placeholder="{{ _('Username') }}"
+              <input id="username" type="text" name="username" placeholder="{{ _('Username / Email')}}"
             value="" class="control-medium" data-module="autocomplete-without-creating-new-options"
             data-module-source="/api/2/util/user/autocomplete?q=?">
           {% endif %}

--- a/ckanext/unaids/theme/templates/package/collaborators/collaborator_new.html
+++ b/ckanext/unaids/theme/templates/package/collaborators/collaborator_new.html
@@ -15,7 +15,7 @@
               <input id="username" name="username" type="text" value="{{ user.name }}"
               disabled="True" class="form-control">
             {% else %}
-                <input id="username" type="text" name="username" placeholder="{{ _('Username') }}"
+                <input id="username" type="text" name="username" placeholder="{{ _('Username / Email')}}"
               value="" class="control-medium" data-module="autocomplete-without-creating-new-options"
               data-module-source="/api/2/util/user/autocomplete?q=?">
             {% endif %}


### PR DESCRIPTION
This change accompanies the PR for ADX-658 in ckanext-emailasusername. 

It makes some small changes to the UI so that the placeholder of user search inputs indicates that you can search by email. 

For instance the restricted fields of a resource...

![image](https://user-images.githubusercontent.com/8988344/118474710-4415db00-b703-11eb-83e4-46ab5cd44e39.png)

![image](https://user-images.githubusercontent.com/8988344/118474866-71fb1f80-b703-11eb-8a38-a403f802563a.png)

Have I missed any other places in the UI where people commonly search for users?
