### PR TITLE
ADX-665-fix-resource-create-restricted-error

### DIFF
--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/index.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/index.js
@@ -12,7 +12,7 @@ const
   lfsServer = getAttr('lfsServer'),
   maxResourceSize = getAttr('maxResourceSize'),
   orgId = getAttr('orgId'),
-  datasetId = getAttr('datasetId'),
+  datasetName = getAttr('datasetName'),
   defaultFields = JSON.parse(getAttr('defaultFields'));
 
 const loadCkan = callback => {
@@ -30,7 +30,7 @@ loadCkan(() => {
   return (
     ReactDOM.render(
       <App {...{
-        lfsServer, maxResourceSize, orgId, datasetId, defaultFields
+        lfsServer, maxResourceSize, orgId, datasetName, defaultFields
       }} />,
       componentElement
     )

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/index.test.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/index.test.js
@@ -41,7 +41,7 @@ async function renderAppComponent(defaultFields) {
       lfsServer: 'mockedLfsServer',
       maxResourceSize: maxResourceSize,
       orgId: 'mockedOrgId',
-      datasetId: 'mockedDatasetId',
+      datasetName: 'mockedDatasetName',
       defaultFields: defaultFields
     };
     render(<App {...mockedAppProps} />);

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
@@ -5,7 +5,7 @@ import FileUploader from './FileUploader';
 import { Client } from 'giftless-client';
 import ProgressBar from './ProgressBar';
 
-export default function App({ lfsServer, maxResourceSize, orgId, datasetId, defaultFields }) {
+export default function App({ lfsServer, maxResourceSize, orgId, datasetName, defaultFields }) {
 
     const [pendingFiles, setPendingFiles] = useState([]);
     const [uploadInProgress, setUploadInProgress] = useState(false);
@@ -30,7 +30,7 @@ export default function App({ lfsServer, maxResourceSize, orgId, datasetId, defa
     const getAuthToken = () =>
         axios.post(
             '/api/3/action/authz_authorize',
-            { scopes: `obj:${orgId}/${datasetId}/*:write` },
+            { scopes: `obj:${orgId}/${datasetName}/*:write` },
             { withCredentials: true }
         )
             .then(res => res.data.result.token)
@@ -39,7 +39,7 @@ export default function App({ lfsServer, maxResourceSize, orgId, datasetId, defa
             ))
     const uploadFile = (client, index, localFile, setFileProgress) =>
         client.upload(
-            localFile, orgId, datasetId,
+            localFile, orgId, datasetName,
             ({ loaded, total }) =>
                 setFileProgress(index, loaded, total + 1)
         ).catch(error => handleNetworkError(
@@ -49,13 +49,13 @@ export default function App({ lfsServer, maxResourceSize, orgId, datasetId, defa
         axios.post(
             '/api/3/action/resource_create',
             {
-                package_id: datasetId,
+                package_id: datasetName,
                 url_type: 'upload',
                 name: localFile._descriptor.name,
                 sha256: localFile._computedHashes.sha256,
                 size: localFile._descriptor.size,
                 url: localFile._descriptor.name,
-                lfs_prefix: `${orgId}/${datasetId}`,
+                lfs_prefix: `${orgId}/${datasetName}`,
                 ...defaultFields
             },
             { withCredentials: true }

--- a/ckanext/unaids/react/components/FileInputComponent/index.js
+++ b/ckanext/unaids/react/components/FileInputComponent/index.js
@@ -12,7 +12,7 @@ const
   maxResourceSize = parseInt(getAttr('maxResourceSize')),
   lfsServer = getAttr('lfsServer'),
   orgId = getAttr('orgId'),
-  datasetId = getAttr('datasetId');
+  datasetName = getAttr('datasetName');
 
 const existingResourceData = {
   urlType: getAttr('existingUrlType'),
@@ -27,7 +27,7 @@ window.addEventListener('load', function () {
   ReactDOM.render(
     <App {...{
       maxResourceSize, lfsServer, orgId,
-      datasetId, existingResourceData
+      datasetName, existingResourceData
     }} />,
     componentElement
   );

--- a/ckanext/unaids/react/components/FileInputComponent/index.test.js
+++ b/ckanext/unaids/react/components/FileInputComponent/index.test.js
@@ -24,7 +24,7 @@ async function renderAppComponent(existingResourceData) {
     const mockedAppProps = {
       lfsServer: 'mockedLfsServer',
       orgId: 'mockedOrgId',
-      datasetId: 'mockedDatasetId',
+      datasetName: 'mockedDatasetName',
       existingResourceData: existingResourceData
     };
     render(<App {...mockedAppProps} />);
@@ -66,7 +66,7 @@ describe('upload a new resource', () => {
       await screen.findByText('data.json');
       expect(mockedAuthTokenRequest).toHaveBeenCalledTimes(1);
       expect(screen.getByTestId('url_type')).toHaveValue('upload');
-      expect(screen.getByTestId('lfs_prefix')).toHaveValue('mockedOrgId/mockedDatasetId');
+      expect(screen.getByTestId('lfs_prefix')).toHaveValue('mockedOrgId/mockedDatasetName');
       expect(screen.getByTestId('sha256')).toHaveValue('mockedSha256');
       expect(screen.getByTestId('size')).toHaveValue('1337');
     }
@@ -120,7 +120,7 @@ describe('view/edit an existing file upload', () => {
   test('view resource', async () => {
     await renderAppComponent(existingResourceData);
     expect(screen.getByTestId('url_type')).toHaveValue(existingResourceData.urlType);
-    expect(screen.getByTestId('lfs_prefix')).toHaveValue('mockedOrgId/mockedDatasetId');
+    expect(screen.getByTestId('lfs_prefix')).toHaveValue('mockedOrgId/mockedDatasetName');
     expect(screen.getByTestId('sha256')).toHaveValue(existingResourceData.sha256);
     expect(screen.getByTestId('size')).toHaveValue(existingResourceData.size);
   });

--- a/ckanext/unaids/react/components/FileInputComponent/src/App.js
+++ b/ckanext/unaids/react/components/FileInputComponent/src/App.js
@@ -6,7 +6,7 @@ import UrlUploader from './UrlUploader';
 import FileUploader from './FileUploader';
 import HiddenFormInputs from './HiddenFormInputs';
 
-export default function App({ maxResourceSize, lfsServer, orgId, datasetId, existingResourceData }) {
+export default function App({ maxResourceSize, lfsServer, orgId, datasetName, existingResourceData }) {
 
     const defaultUploadProgress = { loaded: 0, total: 0 };
     const [uploadMode, setUploadMode] = useState();
@@ -23,7 +23,7 @@ export default function App({ maxResourceSize, lfsServer, orgId, datasetId, exis
                 case 'file':
                     return {
                         url_type: 'upload',
-                        lfs_prefix: [orgId, datasetId].join('/'),
+                        lfs_prefix: `${orgId}/${datasetName}`,
                         sha256: metadata.sha256,
                         size: metadata.size,
                         url: metadata.url
@@ -107,7 +107,7 @@ export default function App({ maxResourceSize, lfsServer, orgId, datasetId, exis
         return (
             [null, 'file'].includes(uploadMode)
                 ? <FileUploader {...{
-                    maxResourceSize, lfsServer, orgId, datasetId,
+                    maxResourceSize, lfsServer, orgId, datasetName,
                     setUploadProgress, setUploadFileName,
                     setHiddenInputs, setUploadError
                 }} />

--- a/ckanext/unaids/react/components/FileInputComponent/src/FileUploader.js
+++ b/ckanext/unaids/react/components/FileInputComponent/src/FileUploader.js
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { Client } from "giftless-client";
 
 export default function FileUploader({
-    maxResourceSize, lfsServer, orgId, datasetId,
+    maxResourceSize, lfsServer, orgId, datasetName,
     setUploadProgress, setUploadFileName, setHiddenInputs,
     setUploadError
 }) {
@@ -12,7 +12,7 @@ export default function FileUploader({
     const getAuthToken = () =>
         axios.post(
             '/api/3/action/authz_authorize',
-            { scopes: `obj:${orgId}/${datasetId}/*:write` },
+            { scopes: `obj:${orgId}/${datasetName}/*:write` },
             { withCredentials: true }
         )
             .then(res => res.data.result.token)
@@ -24,7 +24,7 @@ export default function FileUploader({
                 throw error;
             });
     const uploadFile = (client, file) =>
-        client.upload(file, orgId, datasetId, progress =>
+        client.upload(file, orgId, datasetName, progress =>
             setUploadProgress({
                 loaded: progress.loaded,
                 total: progress.total

--- a/ckanext/unaids/theme/templates/package/snippets/bulk_file_uploader.html
+++ b/ckanext/unaids/theme/templates/package/snippets/bulk_file_uploader.html
@@ -26,7 +26,7 @@
                             data-lfsServer="{{ h.extstorage_server_url() }}"
                             data-maxResourceSize="{{ h.max_resource_size() }}"
                             data-orgId="{{ pkg.organization.name }}"
-                            data-datasetId="{{ pkg.name }}"
+                            data-datasetName="{{ pkg.name }}"
                             data-defaultFields="{{ h.bulk_file_uploader_default_fields() }}"
                         >
                             <span class="text-muted">{{ _('Loading') }}</span>

--- a/ckanext/unaids/theme/templates/scheming/form_snippets/upload.html
+++ b/ckanext/unaids/theme/templates/scheming/form_snippets/upload.html
@@ -1,11 +1,13 @@
 {% asset 'ckanext-unaids/FileInputComponentStyles' %}
 
+{% set dataset = h.get_package_from_id(pkg_name) %}
+
 <div
     id="FileInputComponent"
     data-lfsServer="{{ h.extstorage_server_url() }}"
     data-maxResourceSize="{{ h.max_resource_size() }}"
-    data-orgId="{{ h.get_package_from_id(data.package_id).organization.name }}"
-    data-datasetId="{{ pkg_name or (data.package_id if data else '') }}"
+    data-orgId="{{ dataset.organization.name }}"
+    data-datasetId="{{ dataset.id }}"
     data-existingUrlType="{{ data.url_type if data else '' }}"
     data-existingUrl="{{ data.url if data else '' }}"
     data-existingSha256="{{ data.sha256 if data else '' }}"

--- a/ckanext/unaids/theme/templates/scheming/form_snippets/upload.html
+++ b/ckanext/unaids/theme/templates/scheming/form_snippets/upload.html
@@ -7,7 +7,7 @@
     data-lfsServer="{{ h.extstorage_server_url() }}"
     data-maxResourceSize="{{ h.max_resource_size() }}"
     data-orgId="{{ dataset.organization.name }}"
-    data-datasetId="{{ dataset.id }}"
+    data-datasetId="{{ dataset.name }}"
     data-existingUrlType="{{ data.url_type if data else '' }}"
     data-existingUrl="{{ data.url if data else '' }}"
     data-existingSha256="{{ data.sha256 if data else '' }}"

--- a/ckanext/unaids/theme/templates/scheming/form_snippets/upload.html
+++ b/ckanext/unaids/theme/templates/scheming/form_snippets/upload.html
@@ -7,7 +7,7 @@
     data-lfsServer="{{ h.extstorage_server_url() }}"
     data-maxResourceSize="{{ h.max_resource_size() }}"
     data-orgId="{{ dataset.organization.name }}"
-    data-datasetId="{{ dataset.name }}"
+    data-datasetName="{{ dataset.name }}"
     data-existingUrlType="{{ data.url_type if data else '' }}"
     data-existingUrl="{{ data.url if data else '' }}"
     data-existingSha256="{{ data.sha256 if data else '' }}"


### PR DESCRIPTION
Card: https://fjelltopp.atlassian.net/browse/ADX-665

## WIP tests
- Here's how far I got with trying to get tests working with this feature
- The issue is that I was getting a 404 when attempting a GET on resource.new
- I'm leaving this for now after sinking in a few hours of work
 
```
import pytest
import ckantoolkit
from bs4 import BeautifulSoup

from ckan.tests import factories
from ckan.lib.helpers import url_for


@pytest.mark.usefixtures("clean_db", "with_request_context")
class TestGiftlessFrontEnd(object):

    def test_giftless_resource_create(self, app):
        user = factories.User()
        dataset = factories.Dataset(
            type="test-schema",
        )
        # url = ckantoolkit.h.url_for(
        #     dataset["type"] + "_resource.new",
        #     id=dataset["id"]
        # )
        url = '{}/{}/resource/new'.format(
            dataset["type"], dataset["name"]
        )
        response = app.get(
            url=url,
            extra_environ={"REMOTE_USER": user["name"]},
            status=200
        )
        soup = BeautifulSoup(response.body)
        assert soup.find("div", {"id": "FileInputComponent"})

```