### PR TITLE
smoother react component loading flow

### DIFF
--- a/ckanext/unaids/react/components/FileInputComponent/index.js
+++ b/ckanext/unaids/react/components/FileInputComponent/index.js
@@ -9,6 +9,7 @@ const getAttr = key => {
   return ['None', ''].includes(val) ? null : val;
 };
 const
+  loadingHtml = componentElement.innerHTML,
   maxResourceSize = parseInt(getAttr('maxResourceSize')),
   lfsServer = getAttr('lfsServer'),
   orgId = getAttr('orgId'),
@@ -26,6 +27,7 @@ const existingResourceData = {
 window.addEventListener('load', function () {
   ReactDOM.render(
     <App {...{
+      loadingHtml,
       maxResourceSize, lfsServer, orgId,
       datasetName, existingResourceData
     }} />,

--- a/ckanext/unaids/react/components/FileInputComponent/src/App.js
+++ b/ckanext/unaids/react/components/FileInputComponent/src/App.js
@@ -6,7 +6,7 @@ import UrlUploader from './UrlUploader';
 import FileUploader from './FileUploader';
 import HiddenFormInputs from './HiddenFormInputs';
 
-export default function App({ maxResourceSize, lfsServer, orgId, datasetName, existingResourceData }) {
+export default function App({ loadingHtml, maxResourceSize, lfsServer, orgId, datasetName, existingResourceData }) {
 
     const defaultUploadProgress = { loaded: 0, total: 0 };
     const [uploadMode, setUploadMode] = useState();
@@ -15,6 +15,7 @@ export default function App({ maxResourceSize, lfsServer, orgId, datasetName, ex
     const [linkUrl, setLinkUrl] = useState();
     const [hiddenInputs, _setHiddenInputs] = useState({});
     const [uploadError, setUploadError] = useState(false);
+    const [useEffectCompleted, setUseEffectCompleted] = useState(false);
 
     const setHiddenInputs = (newUploadMode, metadata) => {
         setUploadMode(newUploadMode);
@@ -72,7 +73,12 @@ export default function App({ maxResourceSize, lfsServer, orgId, datasetName, ex
             // resource has no file or link
             setHiddenInputs(null, {});
         };
+        setUseEffectCompleted(true);
     }, []);
+
+    if (!useEffectCompleted) {
+        return <div dangerouslySetInnerHTML={{ __html: loadingHtml }}></div>
+    }
 
     if (uploadError) return (
         <div className="alert alert-danger">
@@ -105,7 +111,7 @@ export default function App({ maxResourceSize, lfsServer, orgId, datasetName, ex
             )
         }
         return (
-            [null, 'file'].includes(uploadMode)
+            [undefined, null, 'file'].includes(uploadMode)
                 ? <FileUploader {...{
                     maxResourceSize, lfsServer, orgId, datasetName,
                     setUploadProgress, setUploadFileName,

--- a/ckanext/unaids/theme/templates/scheming/form_snippets/upload.html
+++ b/ckanext/unaids/theme/templates/scheming/form_snippets/upload.html
@@ -15,7 +15,25 @@
     data-existingSize="{{ data.size if data else '' }}"
 >       
     {% if data.url %}
-        <h3 class="text-muted"><i class="fa fa-spinner fa-spin"></i> {{ _('Loading') }}</h3>
+        {% if data.url_type == 'upload' %}
+            <h3 class="text-muted">
+                <span><i class="fa fa-spinner fa-spin"></i> {{ _('Loading') }}</span>
+            </h3>
+        {% else %}
+            <div>
+                <label class="control-label">{{ _('URL')}}</label>
+                <div class="input-group field-url-input-group">
+                    <input
+                        type="text"
+                        placeholder="{{ _('Loading') }}..."
+                        class="form-control"
+                    />
+                    <span class="input-group-btn">
+                        <button class="btn btn-danger" type="button">{{ _('Remove') }}</button>
+                    </span>
+                </div>
+            </div>
+        {% endif %}
     {% else %}
         <div class="dropzone text-muted">
             <h3><i class="fa fa-spinner fa-spin"></i> {{ _('Loading') }}</h3>


### PR DESCRIPTION
# Problem
- The react single file uploader renders content before all states have been updated
- This causes the url field to display regardless if there's already a url/file set which causes an odd lag effect
- You can see it here: https://youtu.be/3mAPjIpSd1g

# Solution
- We're now reading the raw html sitting inside the component pre-render and storing it. We then display it until the UseEffect has completed running and all states have been updated.