### PR TITLE
ADX-715 dataset releases frontend updates

### DIFF
--- a/ckanext/unaids/theme/public/custom.css
+++ b/ckanext/unaids/theme/public/custom.css
@@ -244,6 +244,11 @@ footer{
   margin-bottom: 10px;
 }
 
+#ReleasesTableContainer .release-date,
+#ReleasesTableContainer .release-actions {
+    margin-top: 10px;
+}
+
 @media (max-width: 991px) {
     #ReleasesTableContainer .release-creator,
     #ReleasesTableContainer .release-notes,

--- a/ckanext/unaids/theme/public/custom.css
+++ b/ckanext/unaids/theme/public/custom.css
@@ -237,6 +237,27 @@ footer{
   margin-bottom: 10px;
 }
 
+#ReleasesTableContainer .release-creator,
+#ReleasesTableContainer .release-notes,
+#ReleasesTableContainer .release-date {
+  padding-left: 35px;
+  margin-bottom: 10px;
+}
+
+@media (max-width: 991px) {
+    #ReleasesTableContainer .release-creator,
+    #ReleasesTableContainer .release-notes,
+    #ReleasesTableContainer .release-date {
+      padding-right: 35px;
+    }
+}
+
+#ReleasesTableContainer .release-actions {
+  padding-right: 27px;
+  margin-bottom: 10px;
+}
+
+
 #ReleasesTableContainer .fixed-table-container {
   border: 1px solid #ddd;
   border-radius: 4px;
@@ -246,39 +267,14 @@ footer{
   border-top: none !important;
 }
 
-@media (max-width: 992px) {
-  /* custom css for mobile view */
-  #ReleasesTableContainer .row>* {
-    padding-top: 0;
-    padding-bottom: 0;
-  }
-  #ReleasesTableContainer .fa-tag {
-    display: none;
-  }
-  #ReleasesTableContainer .release-creator, .btn-group {
-    margin-top: 10px;
-  }
+#ReleasesTableContainer .fa-tag {
+margin-left: 10px;
+margin-right: 5px;
+}
+#ReleasesTableContainer .btn-group {
+float: right;
 }
 
-@media (min-width: 768px) {
-  /* custom css for desktop view */
-  #ReleasesTableContainer .row>* {
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-  #ReleasesTableContainer .vertical-align {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-  }
-  #ReleasesTableContainer .fa-tag {
-    margin-left: 10px;
-    margin-right: 5px;
-  }
-  #ReleasesTableContainer .btn-group {
-    float: right;
-  }
-}
 
 #RestoreOrDeleteReleaseContainer h3 {
   margin: 0;

--- a/ckanext/unaids/theme/public/custom.css
+++ b/ckanext/unaids/theme/public/custom.css
@@ -221,23 +221,65 @@ footer{
   vertical-align: top !important;
 }
 
-#ReleasesTableContainer{
+.text-white {
+  color: white;
+}
+
+#ReleasesTableContainer {
   display: none;
 }
 
-#ReleasesTableContainer .fixed-table-container{
+#ReleasesTableContainer .table {
+  overflow: hidden
+}
+
+#ReleasesTableContainer .release-notes {
+  margin-bottom: 10px;
+}
+
+#ReleasesTableContainer .fixed-table-container {
   border: 1px solid #ddd;
-  border-radius: 4px;  
+  border-radius: 4px;
 }
 
-#ReleasesTableContainer .small-column{
-  max-width: 150px;
-}
-
-#ReleasesTableContainer tbody tr:first-child td{
+#ReleasesTableContainer tbody tr:first-child td {
   border-top: none !important;
 }
 
-#RestoreOrDeleteReleaseContainer h3{
+@media (max-width: 992px) {
+  /* custom css for mobile view */
+  #ReleasesTableContainer .row>* {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+  #ReleasesTableContainer .fa-tag {
+    display: none;
+  }
+  #ReleasesTableContainer .release-creator, .btn-group {
+    margin-top: 10px;
+  }
+}
+
+@media (min-width: 768px) {
+  /* custom css for desktop view */
+  #ReleasesTableContainer .row>* {
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+  #ReleasesTableContainer .vertical-align {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  #ReleasesTableContainer .fa-tag {
+    margin-left: 10px;
+    margin-right: 5px;
+  }
+  #ReleasesTableContainer .btn-group {
+    float: right;
+  }
+}
+
+#RestoreOrDeleteReleaseContainer h3 {
   margin: 0;
 }

--- a/ckanext/unaids/theme/templates/package/read_base.html
+++ b/ckanext/unaids/theme/templates/package/read_base.html
@@ -20,7 +20,7 @@ icon='clock-o') }}
   <div class="module-content">
   {% set release = h.get_current_dataset_release(dataset_id, request.args.activity_id) %}
   {% if release %}
-    <h2 style="margin: 0;"><u>{{ release.name }}</u></h2>
+    <h2 style="margin: 0;"><b>{{ release.name }}</b></h2>
     <p class="text-muted">
       <span>{{ _('Description') }}: </span>
       <span>{{ release.notes or _('None set') }}</span>

--- a/ckanext/unaids/theme/templates/package/releases/list.html
+++ b/ckanext/unaids/theme/templates/package/releases/list.html
@@ -17,10 +17,10 @@
         </p>
     {% else %}
         <div class="btn-group">
-            <a href="{{ urls.create_from_latest_version }}" class="btn btn-danger">
+            <a href="{{ urls.create_from_latest_version }}" class="btn btn-primary">
                 <span>{{ _('Add Release') }}</span>
             </a>
-            <button type="button" class="btn btn-danger dropdown-toggle" data-toggle="dropdown">
+            <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
                 <span class="caret"></span>
             </button>
             <ul class="dropdown-menu">

--- a/ckanext/unaids/theme/templates/package/releases/list.html
+++ b/ckanext/unaids/theme/templates/package/releases/list.html
@@ -26,16 +26,12 @@
             <ul class="dropdown-menu">
                 <li>
                     <a href="{{ urls.create_from_latest_version }}">
-                        <span>{{ _('From the') }} </span>
-                        <u>{{ _('latest version') }} </u>
-                        <span>{{ _('of the dataset') }}</span>
+                        <span>{{ _('From the latest version of the dataset') }}</span>
                     </a>
                 </li>
                 <li>
                     <a href="{{ urls.create_from_an_older_version }}">
-                        <span>{{ _('From a') }} </span>
-                        <u>{{ _('past version') }} </u>
-                        <span>{{ _('of the dataset') }}</span>
+                        <span>{{ _('From a past version of the dataset') }}</span>
                     </a>
                 </li>
             </ul>

--- a/ckanext/unaids/theme/templates/package/releases/list.html
+++ b/ckanext/unaids/theme/templates/package/releases/list.html
@@ -26,12 +26,12 @@
             <ul class="dropdown-menu">
                 <li>
                     <a href="{{ urls.create_from_latest_version }}">
-                        <span>{{ _('From the latest version of the dataset') }}</span>
+                        <span>{{ _('From <b>the latest version</b> of the dataset') }}</span>
                     </a>
                 </li>
                 <li>
                     <a href="{{ urls.create_from_an_older_version }}">
-                        <span>{{ _('From a past version of the dataset') }}</span>
+                        <span>{{ _('From <b>a past version</b> of the dataset') }}</span>
                     </a>
                 </li>
             </ul>

--- a/ckanext/unaids/theme/templates/package/releases/list.html
+++ b/ckanext/unaids/theme/templates/package/releases/list.html
@@ -63,33 +63,35 @@
                 <tr>
                     <td>
                         <div class="row vertical-align">
-                            <div class="col-sm-6">                                
-                                <h4><i class="fa fa-tag text-muted fa-fw"></i><a href="{{ h.url_for('dataset.read', id=pkg_dict.name, activity_id=release.activity_id) }}">{{ release.name }}</a></h4> 
+                            <div class="col-xs-12 col-md-6">
+                                <div class="release-title"><h4><i class="fa fa-tag text-muted fa-fw"></i><a href="{{ h.url_for('dataset.read', id=pkg_dict.name, activity_id=release.activity_id) }}">{{ release.name }}</a></h4></div>
                                 {% if release.notes %}
-                                    <div class="text-muted release-notes"><i class="fa fa-tag fa-fw text-white"></i>{{ release.notes }}</div>                                    
+                                    <div class="text-muted release-notes">{{ release.notes }}</div>
                                 {% endif %}
-                                    <div class="release-creator"><i class="fa fa-tag fa-fw text-white"></i>{{ _('Created by') }} {{ h.linked_user(release.creator_user_id, 0, 0) }}</a></div>
+                                    <div class="release-creator">{{ _('Created by') }} {{ h.linked_user(release.creator_user_id, 0, 0) }}</a></div>
                             </div>
-                            <div class="col-sm-3">
-                                <span title="{{ h.render_datetime(release.created, with_hours=True) }}">{{ h.time_ago_from_timestamp(release.created) }}</span>
+                            <div class="col-md-3">
+                                <div class="release-date"><span title="{{ h.render_datetime(release.created, with_hours=True) }}">{{ h.time_ago_from_timestamp(release.created) }}</span></div>
                             </div>
-                            <div class="col-sm-3">
-                                <div class="btn-group btn-group-xs">
-                                    <a
-                                        href="{{ h.url_for('unaids_dataset_releases.release_restore', dataset_type=dataset_type, dataset_id=pkg.name, release_id=release.id) }}"
-                                        class="btn btn-default"
-                                        title="{{ _('Make release the latest version') }}"
-                                    ><i class="fa fa-refresh"></i></a>
-                                    <a
-                                        href="{{ h.url_for('unaids_dataset_releases.release_view', dataset_type=dataset_type, dataset_id=pkg.name, release_id=release.id) }}"
-                                        class="btn btn-default"
-                                        title="{{ _('Edit Release') }}"
-                                    ><i class="fa fa-pencil"></i></a>
-                                    <a
-                                        href="{{ h.url_for('unaids_dataset_releases.release_delete', dataset_type=dataset_type, dataset_id=pkg.name, release_id=release.id) }}"
-                                        class="btn btn-default"
-                                        title="{{ _('Delete Release') }}"
-                                    ><i class="fa fa-trash"></i></a>
+                            <div class="col-xs-12 col-md-3">
+                                <div class="release-actions">
+                                    <div class="btn-group btn-group-xs">
+                                        <a
+                                            href="{{ h.url_for('unaids_dataset_releases.release_restore', dataset_type=dataset_type, dataset_id=pkg.name, release_id=release.id) }}"
+                                            class="btn btn-default"
+                                            title="{{ _('Make release the latest version') }}"
+                                        ><i class="fa fa-refresh"></i></a>
+                                        <a
+                                            href="{{ h.url_for('unaids_dataset_releases.release_view', dataset_type=dataset_type, dataset_id=pkg.name, release_id=release.id) }}"
+                                            class="btn btn-default"
+                                            title="{{ _('Edit Release') }}"
+                                        ><i class="fa fa-pencil"></i></a>
+                                        <a
+                                            href="{{ h.url_for('unaids_dataset_releases.release_delete', dataset_type=dataset_type, dataset_id=pkg.name, release_id=release.id) }}"
+                                            class="btn btn-default"
+                                            title="{{ _('Delete Release') }}"
+                                        ><i class="fa fa-trash"></i></a>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -107,7 +109,7 @@
                 pagination: true,
                 pageSize: 5,
                 paginationParts: "pageList"
-            });        
+            });
             $('#ReleasesLoading').remove();
             $('#ReleasesTableContainer')
                 .css('opacity', 0)
@@ -127,5 +129,3 @@
 {% endif %}
 
 {% endblock %}
-
-

--- a/ckanext/unaids/theme/templates/package/releases/list.html
+++ b/ckanext/unaids/theme/templates/package/releases/list.html
@@ -75,20 +75,11 @@
                             </div>
                             <div class="col-sm-3">
                                 <div class="btn-group btn-group-xs">
-                                    {% if loop.index == 1 %}
-                                        <button
-                                            class="btn btn-default disabled"
-                                            title="{{ _('Disabled') }}"
-                                        >
-                                        <i class="fa fa-refresh"></i>
-                                        </button>
-                                    {% else %}
-                                        <a
-                                            href="{{ h.url_for('unaids_dataset_releases.release_restore', dataset_type=dataset_type, dataset_id=pkg.name, release_id=release.id) }}"
-                                            class="btn btn-default"
-                                            title="{{ _('Make release the latest version') }}"
-                                        ><i class="fa fa-refresh"></i></a>
-                                    {% endif %}
+                                    <a
+                                        href="{{ h.url_for('unaids_dataset_releases.release_restore', dataset_type=dataset_type, dataset_id=pkg.name, release_id=release.id) }}"
+                                        class="btn btn-default"
+                                        title="{{ _('Make release the latest version') }}"
+                                    ><i class="fa fa-refresh"></i></a>
                                     <a
                                         href="{{ h.url_for('unaids_dataset_releases.release_view', dataset_type=dataset_type, dataset_id=pkg.name, release_id=release.id) }}"
                                         class="btn btn-default"

--- a/ckanext/unaids/theme/templates/package/releases/list.html
+++ b/ckanext/unaids/theme/templates/package/releases/list.html
@@ -59,53 +59,52 @@
         <table>
             <thead>
                 <tr>
-                    <th data-width="50"></th>
                     <th></th>
-                    <th class="small-column text-right"></th>
-                    <th class="small-column text-right"></th>
                 </tr>
             </thead>
             <tbody>
                 {% for release in dataset_releases %}
                 <tr>
-                    <td class="text-right vertical-align-top">
-                        <h4><i class="fa fa-tag text-muted"></i></h4>
-                    </td>
-                    <td class="vertical-align-top">
-                        <h4><a href="{{ h.url_for('dataset.read', id=pkg_dict.name, activity_id=release.activity_id) }}">{{ release.name }}</a></h4> 
-                        <div class="text-muted">{{ release.notes }}</div>
-                        <div class="text-muted">Created by{{ h.linked_user(release.creator_user_id, 0, 0) }}</a></div>
-                        <br>
-                    </td>
                     <td>
-                        <p title="{{ h.render_datetime(release.created, with_hours=True) }}">{{ h.time_ago_from_timestamp(release.created) }}</p>
-                    </td>
-                    <td>
-                        <div class="btn-group pull-right btn-group-xs">
-                            {% if loop.index == 1 %}
-                                <button
-                                    class="btn btn-default disabled"
-                                    title="{{ _('Disabled') }}"
-                                >
-                                <i class="fa fa-refresh"></i>
-                                </button>
-                            {% else %}
-                                <a
-                                    href="{{ h.url_for('unaids_dataset_releases.release_restore', dataset_type=dataset_type, dataset_id=pkg.name, release_id=release.id) }}"
-                                    class="btn btn-default"
-                                    title="{{ _('Make release the latest version') }}"
-                                ><i class="fa fa-refresh"></i></a>
-                            {% endif %}
-                            <a
-                                href="{{ h.url_for('unaids_dataset_releases.release_view', dataset_type=dataset_type, dataset_id=pkg.name, release_id=release.id) }}"
-                                class="btn btn-default"
-                                title="{{ _('Edit Release') }}"
-                            ><i class="fa fa-pencil"></i></a>
-                            <a
-                                href="{{ h.url_for('unaids_dataset_releases.release_delete', dataset_type=dataset_type, dataset_id=pkg.name, release_id=release.id) }}"
-                                class="btn btn-default"
-                                title="{{ _('Delete Release') }}"
-                            ><i class="fa fa-trash"></i></a>
+                        <div class="row vertical-align">
+                            <div class="col-sm-6">                                
+                                <h4><i class="fa fa-tag text-muted fa-fw"></i><a href="{{ h.url_for('dataset.read', id=pkg_dict.name, activity_id=release.activity_id) }}">{{ release.name }}</a></h4> 
+                                {% if release.notes %}
+                                    <div class="text-muted release-notes"><i class="fa fa-tag fa-fw text-white"></i>{{ release.notes }}</div>                                    
+                                {% endif %}
+                                    <div class="release-creator"><i class="fa fa-tag fa-fw text-white"></i>{{ _('Created by') }} {{ h.linked_user(release.creator_user_id, 0, 0) }}</a></div>
+                            </div>
+                            <div class="col-sm-3">
+                                <span title="{{ h.render_datetime(release.created, with_hours=True) }}">{{ h.time_ago_from_timestamp(release.created) }}</span>
+                            </div>
+                            <div class="col-sm-3">
+                                <div class="btn-group btn-group-xs">
+                                    {% if loop.index == 1 %}
+                                        <button
+                                            class="btn btn-default disabled"
+                                            title="{{ _('Disabled') }}"
+                                        >
+                                        <i class="fa fa-refresh"></i>
+                                        </button>
+                                    {% else %}
+                                        <a
+                                            href="{{ h.url_for('unaids_dataset_releases.release_restore', dataset_type=dataset_type, dataset_id=pkg.name, release_id=release.id) }}"
+                                            class="btn btn-default"
+                                            title="{{ _('Make release the latest version') }}"
+                                        ><i class="fa fa-refresh"></i></a>
+                                    {% endif %}
+                                    <a
+                                        href="{{ h.url_for('unaids_dataset_releases.release_view', dataset_type=dataset_type, dataset_id=pkg.name, release_id=release.id) }}"
+                                        class="btn btn-default"
+                                        title="{{ _('Edit Release') }}"
+                                    ><i class="fa fa-pencil"></i></a>
+                                    <a
+                                        href="{{ h.url_for('unaids_dataset_releases.release_delete', dataset_type=dataset_type, dataset_id=pkg.name, release_id=release.id) }}"
+                                        class="btn btn-default"
+                                        title="{{ _('Delete Release') }}"
+                                    ><i class="fa fa-trash"></i></a>
+                                </div>
+                            </div>
                         </div>
                     </td>
                 </tr>


### PR DESCRIPTION
[Jira ticket ADX-715](https://fjelltopp.atlassian.net/jira/software/projects/ADX/boards/4?selectedIssue=ADX-715)


## Releases list view is now responsive and mobile friendly
▶️ [View video of responsiveness](https://youtu.be/CzaulymHjx0)

| before     | after    |
|-------|-----------------------|
| ![image](https://user-images.githubusercontent.com/2634482/123825996-48830580-d8f7-11eb-8a4b-91d6cfb7d1a5.png) | ![image](https://user-images.githubusercontent.com/2634482/123826035-4faa1380-d8f7-11eb-8cf2-0d8524cf7f57.png)
| ![image](https://user-images.githubusercontent.com/2634482/123823377-0a84e200-d8f5-11eb-835e-9d79cca800fb.png) | ![image](https://user-images.githubusercontent.com/2634482/123823398-0f499600-d8f5-11eb-8662-66b92996c2f0.png) |

## underlines have now been changed/removed
I tried replacing the `<u>` with a `<b>` however we don't seem to support bold with the font we're using anywhere on the ADR, which is a little odd. The UI isn't hugely changed by removing underlines anyway, so we can keep it like this until we look into the bold issue.

| before     | after    |
|-------|-----------------------|
| ![image](https://user-images.githubusercontent.com/2634482/123824261-c9d99880-d8f5-11eb-99b8-2a189bc298f6.png) | ![image](https://user-images.githubusercontent.com/2634482/123823998-90a12880-d8f5-11eb-9fb0-6d55b3f07b63.png)
| ![image](https://user-images.githubusercontent.com/2634482/123825188-9a775b80-d8f6-11eb-8f78-b0b775782a0d.png) | ![image](https://user-images.githubusercontent.com/2634482/123825263-aebb5880-d8f6-11eb-81e6-dae863cf4376.png)



