### PR TITLE
ADX-718 Fixed __ filename error

### DIFF
--- a/ckanext/unaids/react/components/FileInputComponent/index.test.js
+++ b/ckanext/unaids/react/components/FileInputComponent/index.test.js
@@ -122,6 +122,7 @@ describe('view/edit an existing file upload', () => {
     expect(screen.getByTestId('url_type')).toHaveValue(existingResourceData.urlType);
     expect(screen.getByTestId('lfs_prefix')).toHaveValue('mockedOrgId/mockedDatasetName');
     expect(screen.getByTestId('sha256')).toHaveValue(existingResourceData.sha256);
+    expect(screen.getByTestId('url')).toHaveValue(existingResourceData.fileName);
     expect(screen.getByTestId('size')).toHaveValue(existingResourceData.size);
   });
 

--- a/ckanext/unaids/react/components/FileInputComponent/src/App.js
+++ b/ckanext/unaids/react/components/FileInputComponent/src/App.js
@@ -63,7 +63,8 @@ export default function App({ loadingHtml, maxResourceSize, lfsServer, orgId, da
             })
             setHiddenInputs('file', {
                 sha256: data.sha256,
-                size: data.size
+                size: data.size,
+                url: data.fileName
             })
         } else if (data.url) {
             // resource already has a url


### PR DESCRIPTION
# Problem
- After uploading a new resource. Go into manage to edit it and change the description.
- The uploaded file will now disappear and the filename will be set to `__`

# Solution
- We were forgetting to set the hidden `url` <input> field when editing a resource which already had a file uploaded to it.
- This was missed as it's easy to confuse the fields for what they mean. The `url` <input> needs to be set to the filename if the resource is a file upload. This isn't super intuitive however it's what the ckan form expects. If the resource is a url, then the url field is however set to a full url 😅 

# Notes
Interestingly, we've never attempted to fix this in the past either:
https://github.com/fjelltopp/ckanext-unaids/commits/development/ckanext/unaids/react/components/FileInputComponent/src/App.js