### PR TITLE
added last_modified timestamp to hidden inputs

### DIFF
--- a/ckanext/unaids/react/components/FileInputComponent/index.test.js
+++ b/ckanext/unaids/react/components/FileInputComponent/index.test.js
@@ -31,6 +31,10 @@ async function renderAppComponent(existingResourceData) {
   })
 };
 
+afterEach(async () => {
+  expect(screen.getByTestId('last_modified')).toHaveValue();
+});
+
 describe('upload a new resource', () => {
 
   beforeEach(async () => {

--- a/ckanext/unaids/react/components/FileInputComponent/src/HiddenFormInputs.js
+++ b/ckanext/unaids/react/components/FileInputComponent/src/HiddenFormInputs.js
@@ -2,6 +2,11 @@ import React from 'react';
 
 export default function HiddenFormInputs({ hiddenInputs }) {
 
+    hiddenInputs = {
+        ...hiddenInputs,
+        last_modified: new Date().toISOString().replace('Z', '')
+    };
+
     return Object.keys(hiddenInputs).map(key => (
         <input
             key={key}


### PR DESCRIPTION
# Note: This is only fixing the single file uploader

# Problem
- When uploading or editing url/file uploads we are never setting or updating the `last_modified` field on the resource

# Solution
- Whenever updating the `HiddenFormInputs` field, update the `last_modified` with a ISO timestamp

# Important gotchas
- The field may be slightly out-of-date as we only update the `last_modified` field whenever there is interaction with this react component. So if a user opens the page, waits 10mins before editing the description of the resource, then the timestamp on save would be 10mins old.
- The `last_modified` field is always updated, which means if a user edits a resource and makes no changes and hits save, then the `last_modified` would be the only field updated. If we want to ignore resource edits where the only change was the `last_modified` then we would need to add validation to the backend.