### PR TITLE
FIX last modified format on giftless_upload

### DIFF
--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -243,9 +243,10 @@ def _giftless_upload(context, resource, current=None):
             )
 
             lfs_prefix = blobstorage_helpers.resource_storage_prefix(dataset_name, org_name=org_name)
+            last_modified = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
             resource.update({
                 'url_type': 'upload',
-                'last_modified': datetime.datetime.utcnow(),
+                'last_modified': last_modified,
                 'sha256': uploaded_file['oid'],
                 'size': uploaded_file['size'],
                 'url': attached_file.filename,


### PR DESCRIPTION
# Problem
- The `last_modified` field in `_giftless_upload` is not being set with Zulu
```
>>> str(datetime.datetime.utcnow())
'2021-07-02 09:51:27.999831'
```

# Solution
- Fix format as per https://stackoverflow.com/a/42777551/2068836
```
>>> datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
'2021-07-02T09:51:30Z'
```