### PR TITLE
ADX-717 fix last updated on resource uploads

### DIFF
--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -256,7 +256,8 @@ def _giftless_upload(context, resource, current=None):
 
 
 def _update_resource_last_modified_date(resource, current=None):
-    current = current or {}
+    if current is None:
+        current = {}
     for key in ['url_type', 'lfs_prefix', 'sha256', 'size', 'url']:
         current_value = str(current.get(key) or '')
         resource_value = str(resource.get(key) or '')

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -174,7 +174,7 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
     def before_update(self, context, current, resource):
         if _data_dict_is_resource(resource):
             _giftless_upload(context, resource, current=current)
-            _update_resource_last_modified_date(resource, current)
+            _update_resource_last_modified_date(resource, current=current)
         return resource
 
 
@@ -255,7 +255,8 @@ def _giftless_upload(context, resource, current=None):
             })
 
 
-def _update_resource_last_modified_date(resource, current={}):
+def _update_resource_last_modified_date(resource, current=None):
+    current = current or {}
     for key in ['url_type', 'lfs_prefix', 'sha256', 'size', 'url']:
         current_value = str(current.get(key) or '')
         resource_value = str(resource.get(key) or '')

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -168,11 +168,13 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
     def before_create(self, context, resource):
         if _data_dict_is_resource(resource):
             _giftless_upload(context, resource)
+            _update_resource_last_modified_date(resource)
         return resource
 
     def before_update(self, context, current, resource):
         if _data_dict_is_resource(resource):
             _giftless_upload(context, resource, current=current)
+            _update_resource_last_modified_date(resource, current)
         return resource
 
 
@@ -251,6 +253,15 @@ def _giftless_upload(context, resource, current=None):
                 'url': attached_file.filename,
                 'lfs_prefix': lfs_prefix
             })
+
+
+def _update_resource_last_modified_date(resource, current={}):
+    for key in ['url_type', 'lfs_prefix', 'sha256', 'size', 'url']:
+        current_value = str(current.get(key) or '')
+        resource_value = str(resource.get(key) or '')
+        if current_value != resource_value:
+            resource['last_modified'] = datetime.datetime.utcnow()
+            return
 
 
 def _get_upload_authz_token(context, dataset_name, org_name):

--- a/ckanext/unaids/react/components/FileInputComponent/index.test.js
+++ b/ckanext/unaids/react/components/FileInputComponent/index.test.js
@@ -122,7 +122,7 @@ describe('view/edit an existing file upload', () => {
     expect(screen.getByTestId('url_type')).toHaveValue(existingResourceData.urlType);
     expect(screen.getByTestId('lfs_prefix')).toHaveValue('mockedOrgId/mockedDatasetName');
     expect(screen.getByTestId('sha256')).toHaveValue(existingResourceData.sha256);
-    expect(screen.getByTestId('url')).toHaveValue(existingResourceData.fileName);
+    expect(screen.getByTestId('url')).toHaveValue(existingResourceData.url);
     expect(screen.getByTestId('size')).toHaveValue(existingResourceData.size);
   });
 

--- a/ckanext/unaids/react/components/FileInputComponent/src/App.js
+++ b/ckanext/unaids/react/components/FileInputComponent/src/App.js
@@ -64,7 +64,7 @@ export default function App({ loadingHtml, maxResourceSize, lfsServer, orgId, da
             setHiddenInputs('file', {
                 sha256: data.sha256,
                 size: data.size,
-                url: data.fileName
+                url: data.url
             })
         } else if (data.url) {
             // resource already has a url

--- a/ckanext/unaids/tests/test_plugin.py
+++ b/ckanext/unaids/tests/test_plugin.py
@@ -9,50 +9,59 @@ from ckanext.unaids.plugin import (
 )
 
 
+def _resource_dict(resource_type='file'):
+    if resource_type == 'file':
+        return {
+            'url_type': 'upload',
+            'url': 'file.csv',
+            'lfs_prefix': 'prefix',
+            'sha256': 'sha256',
+            'size': 100,
+        }
+    elif resource_type == 'link':
+        return {
+            'url_type': '',
+            'url': 'http://example.com'
+        }
+    else:
+        raise ValueError("Unsupported resource type %s", resource_type)
+
+
 @pytest.fixture
 def resource_with_file():
-    return {
-        'url_type': 'upload',
-        'url': 'file.csv',
-        'lfs_prefix': 'prefix',
-        'sha256': 'sha256',
-        'size': 100,
-    }
+    return _resource_dict(resource_type='file')
 
 
 @pytest.fixture
 def resource_with_link():
-    return {
-        'url_type': '',
-        'url': 'http://example.com'
-    }
+    return _resource_dict(resource_type='link')
 
 
 @pytest.fixture
 def resource_with_updated_file():
-    updated_resource = resource_with_file()
-    updated_resource.update({'url': 'file2.csv'})
+    updated_resource = _resource_dict(resource_type='file')
+    updated_resource['url'] = 'file2.csv'
     return updated_resource
 
 
 @pytest.fixture
 def resource_with_updated_link():
-    updated_resource = resource_with_link()
-    updated_resource.update({'url': 'http://example2.com'})
+    updated_resource = _resource_dict(resource_type='link')
+    updated_resource['url'] = 'http://example2.com'
     return updated_resource
 
 
 @pytest.fixture
 def resource_with_file_and_updated_metadata():
-    updated_resource = resource_with_file()
-    updated_resource.update({'key': 'value'})
+    updated_resource = _resource_dict(resource_type='file')
+    updated_resource['description'] = 'updated-description'
     return updated_resource
 
 
 @pytest.fixture
 def resource_with_link_and_updated_metadata():
-    updated_resource = resource_with_link()
-    updated_resource.update({'key': 'value'})
+    updated_resource = _resource_dict(resource_type='link')
+    updated_resource['description'] = 'updated-description'
     return updated_resource
 
 

--- a/ckanext/unaids/tests/test_plugin.py
+++ b/ckanext/unaids/tests/test_plugin.py
@@ -9,6 +9,53 @@ from ckanext.unaids.plugin import (
 )
 
 
+@pytest.fixture
+def resource_with_file():
+    return {
+        'url_type': 'upload',
+        'url': 'file.csv',
+        'lfs_prefix': 'prefix',
+        'sha256': 'sha256',
+        'size': 100,
+    }
+
+
+@pytest.fixture
+def resource_with_link():
+    return {
+        'url_type': '',
+        'url': 'http://example.com'
+    }
+
+
+@pytest.fixture
+def resource_with_updated_file():
+    updated_resource = resource_with_file()
+    updated_resource.update({'url': 'file2.csv'})
+    return updated_resource
+
+
+@pytest.fixture
+def resource_with_updated_link():
+    updated_resource = resource_with_link()
+    updated_resource.update({'url': 'http://example2.com'})
+    return updated_resource
+
+
+@pytest.fixture
+def resource_with_file_and_updated_metadata():
+    updated_resource = resource_with_file()
+    updated_resource.update({'key': 'value'})
+    return updated_resource
+
+
+@pytest.fixture
+def resource_with_link_and_updated_metadata():
+    updated_resource = resource_with_link()
+    updated_resource.update({'key': 'value'})
+    return updated_resource
+
+
 @pytest.mark.ckan_config('ckan.plugins', 'unaids')
 @pytest.mark.usefixtures('with_plugins')
 class TestPlugin(object):
@@ -42,23 +89,6 @@ class TestResourceLastModified(object):
     whenever a resource is created or edited.
     '''
 
-    @pytest.fixture
-    def resource_with_file(autouse=True):
-        return {
-            'url_type': 'upload',
-            'url': 'file.csv',
-            'lfs_prefix': 'prefix123',
-            'sha256': 'sha256',
-            'size': 100,
-        }
-
-    @pytest.fixture
-    def resource_with_link(autouse=True):
-        return {
-            'url_type': '',
-            'url': 'http://example.com'
-        }
-
     def test_null_to_file_should_update_last_modified_datetime(self, resource_with_file):
         _update_resource_last_modified_date(resource_with_file)
         assert 'last_modified' in resource_with_file
@@ -70,27 +100,26 @@ class TestResourceLastModified(object):
         )
         assert 'last_modified' not in resource_with_file
 
-    def test_file_to_file_should_update_last_modified_datetime(self, resource_with_file):
-        updated_resource = resource_with_file.copy()
-        updated_resource.update({'url': 'file2.csv'})
+    def test_file_to_file_should_update_last_modified_datetime(
+            self, resource_with_file, resource_with_updated_file):
         _update_resource_last_modified_date(
-            updated_resource, current=resource_with_file
+            resource_with_updated_file, current=resource_with_file
         )
-        assert 'last_modified' in updated_resource
+        assert 'last_modified' in resource_with_updated_file
 
-    def test_file_to_link_should_update_last_modified_datetime(self, resource_with_file, resource_with_link):
+    def test_file_to_link_should_update_last_modified_datetime(
+            self, resource_with_file, resource_with_link):
         _update_resource_last_modified_date(
             resource_with_link, current=resource_with_file
         )
         assert 'last_modified' in resource_with_link
 
-    def test_changing_metadata_in_file_should_not_update_last_modified_datetime(self, resource_with_file):
-        updated_resource = resource_with_file.copy()
-        updated_resource.update({'key': 'value'})
+    def test_changing_metadata_in_file_should_not_update_last_modified_datetime(
+            self, resource_with_file, resource_with_file_and_updated_metadata):
         _update_resource_last_modified_date(
-            resource_with_file, current=resource_with_file
+            resource_with_file_and_updated_metadata, current=resource_with_file
         )
-        assert 'last_modified' not in updated_resource
+        assert 'last_modified' not in resource_with_file_and_updated_metadata
 
     def test_null_to_link_should_update_last_modified_datetime(self, resource_with_link):
         _update_resource_last_modified_date(resource_with_link)
@@ -103,24 +132,23 @@ class TestResourceLastModified(object):
         )
         assert 'last_modified' not in resource_with_link
 
-    def test_link_to_link_should_update_last_modified_datetime(self, resource_with_link):
-        updated_resource = resource_with_link.copy()
-        updated_resource.update({'url': 'http://example2.com'})
+    def test_link_to_link_should_update_last_modified_datetime(
+            self, resource_with_link, resource_with_updated_link):
         _update_resource_last_modified_date(
-            updated_resource, current=resource_with_link
+            resource_with_updated_link, current=resource_with_link
         )
-        assert 'last_modified' in updated_resource
+        assert 'last_modified' in resource_with_updated_link
 
-    def test_link_to_file_should_update_last_modified_datetime(self, resource_with_file, resource_with_link):
+    def test_link_to_file_should_update_last_modified_datetime(
+            self, resource_with_file, resource_with_link):
         _update_resource_last_modified_date(
             resource_with_file, current=resource_with_link
         )
         assert 'last_modified' in resource_with_file
 
-    def test_changing_metadata_in_link_should_not_update_last_modified_datetime(self, resource_with_link):
-        updated_resource = resource_with_link.copy()
-        updated_resource.update({'key': 'value'})
+    def test_changing_metadata_in_link_should_not_update_last_modified_datetime(
+            self, resource_with_link, resource_with_link_and_updated_metadata):
         _update_resource_last_modified_date(
-            resource_with_link, current=resource_with_link
+            resource_with_link_and_updated_metadata, current=resource_with_link
         )
-        assert 'last_modified' not in updated_resource
+        assert 'last_modified' not in resource_with_link_and_updated_metadata

--- a/ckanext/unaids/tests/test_plugin.py
+++ b/ckanext/unaids/tests/test_plugin.py
@@ -4,6 +4,9 @@
 from ckan.tests.helpers import call_action
 from ckan.tests import factories
 import pytest
+from ckanext.unaids.plugin import (
+    _update_resource_last_modified_date
+)
 
 
 @pytest.mark.ckan_config('ckan.plugins', 'unaids')
@@ -30,3 +33,61 @@ class TestPlugin(object):
         response = call_action('resource_create', {}, **resource)
         response = call_action('package_show', {}, id=dataset['id'])
         assert response['resources'][0]['format'] == 'GeoJSON'
+
+
+class TestResourceLastModified(object):
+    '''Tests for the ckanext.plugin._update_resource_last_modified_date module.
+
+    Make sure we are setting the last_modified to the resource dict
+    whenever a resource is created or edited.
+    '''
+
+    URL_TYPE_FILE_UPLOAD = 'upload'
+    URL_TYPE_LINK = ''
+
+    def test_resource(self, url_type):
+        resource_dict = {'url_type': url_type}
+        if url_type == self.URL_TYPE_FILE_UPLOAD:
+            resource_dict.update({
+                'url': 'file.csv',
+                'lfs_prefix': 'prefix123',
+                'sha256': 'sha256',
+                'size': 100,
+            })
+        elif url_type == self.URL_TYPE_LINK:
+            resource_dict.update({
+                'url': 'http://example.com'
+            })
+        return resource_dict
+
+    def test_null_to_file(self):
+        resource = self.test_resource(self.URL_TYPE_FILE_UPLOAD)
+        _update_resource_last_modified_date(resource=resource)
+        assert 'last_modified' in resource
+
+    def test_file_to_null(self):
+        resource = self.test_resource(self.URL_TYPE_FILE_UPLOAD)
+        _update_resource_last_modified_date({}, resource)
+        assert 'last_modified' not in resource
+
+    def test_file_to_url(self):
+        current = self.test_resource(self.URL_TYPE_FILE_UPLOAD)
+        resource = self.test_resource(self.URL_TYPE_LINK)
+        _update_resource_last_modified_date(resource, current)
+        assert 'last_modified' in resource
+
+    def test_null_to_url(self):
+        resource = self.test_resource(self.URL_TYPE_LINK)
+        _update_resource_last_modified_date(resource=resource)
+        assert 'last_modified' in resource
+
+    def test_url_to_null(self):
+        resource = self.test_resource(self.URL_TYPE_LINK)
+        _update_resource_last_modified_date({}, resource)
+        assert 'last_modified' not in resource
+
+    def test_url_to_file(self):
+        current = self.test_resource(self.URL_TYPE_LINK)
+        resource = self.test_resource(self.URL_TYPE_FILE_UPLOAD)
+        _update_resource_last_modified_date(resource, current)
+        assert 'last_modified' in resource

--- a/ckanext/unaids/tests/test_plugin.py
+++ b/ckanext/unaids/tests/test_plugin.py
@@ -59,18 +59,18 @@ class TestResourceLastModified(object):
             'url': 'http://example.com'
         }
 
-    def test_null_to_file(self, resource_with_file):
+    def test_null_to_file_should_update_last_modified_datetime(self, resource_with_file):
         _update_resource_last_modified_date(resource_with_file)
         assert 'last_modified' in resource_with_file
 
-    def test_file_to_null(self, resource_with_file):
+    def test_file_to_null_should_not_update_last_modified_datetime(self, resource_with_file):
         null_resource = {}
         _update_resource_last_modified_date(
             null_resource, current=resource_with_file
         )
         assert 'last_modified' not in resource_with_file
 
-    def test_file_to_file(self, resource_with_file):
+    def test_file_to_file_should_update_last_modified_datetime(self, resource_with_file):
         updated_resource = resource_with_file.copy()
         updated_resource.update({'url': 'file2.csv'})
         _update_resource_last_modified_date(
@@ -78,32 +78,32 @@ class TestResourceLastModified(object):
         )
         assert 'last_modified' in updated_resource
 
-    def test_file_to_link(self, resource_with_file, resource_with_link):
+    def test_file_to_link_should_update_last_modified_datetime(self, resource_with_file, resource_with_link):
         _update_resource_last_modified_date(
             resource_with_link, current=resource_with_file
         )
         assert 'last_modified' in resource_with_link
 
-    def test_changing_random_metadata_in_file(self, resource_with_file):
+    def test_changing_metadata_in_file_should_not_update_last_modified_datetime(self, resource_with_file):
         updated_resource = resource_with_file.copy()
-        updated_resource.update({'random_key': 'random_value'})
+        updated_resource.update({'key': 'value'})
         _update_resource_last_modified_date(
             resource_with_file, current=resource_with_file
         )
         assert 'last_modified' not in updated_resource
 
-    def test_null_to_link(self, resource_with_link):
+    def test_null_to_link_should_update_last_modified_datetime(self, resource_with_link):
         _update_resource_last_modified_date(resource_with_link)
         assert 'last_modified' in resource_with_link
 
-    def test_link_to_null(self, resource_with_link):
+    def test_link_to_null_should_not_update_last_modified_datetime(self, resource_with_link):
         null_resource = {}
         _update_resource_last_modified_date(
             null_resource, current=resource_with_link
         )
         assert 'last_modified' not in resource_with_link
 
-    def test_link_to_link(self, resource_with_link):
+    def test_link_to_link_should_update_last_modified_datetime(self, resource_with_link):
         updated_resource = resource_with_link.copy()
         updated_resource.update({'url': 'http://example2.com'})
         _update_resource_last_modified_date(
@@ -111,15 +111,15 @@ class TestResourceLastModified(object):
         )
         assert 'last_modified' in updated_resource
 
-    def test_link_to_file(self, resource_with_file, resource_with_link):
+    def test_link_to_file_should_update_last_modified_datetime(self, resource_with_file, resource_with_link):
         _update_resource_last_modified_date(
             resource_with_file, current=resource_with_link
         )
         assert 'last_modified' in resource_with_file
 
-    def test_changing_random_metadata_in_link(self, resource_with_link):
+    def test_changing_metadata_in_link_should_not_update_last_modified_datetime(self, resource_with_link):
         updated_resource = resource_with_link.copy()
-        updated_resource.update({'random_key': 'random_value'})
+        updated_resource.update({'key': 'value'})
         _update_resource_last_modified_date(
             resource_with_link, current=resource_with_link
         )


### PR DESCRIPTION
# Problem
- When uploading urls/files through the single or bulk file uploaders, we are never setting the `last_updated` field on the resource

# Solution
- Using `before_create` and `before_update` set `last_updated` to a timestamp if (and only if) a change has been made to the file or url fields which involves tracking `['url_type', 'lfs_prefix', 'sha256', 'size', 'url']` for any changes.
- The react single file uploader has also been updated to us the `existingResourceData.url` in the resource `url` field, rather than `fileName`.