### PR TITLE
ADX-721 add fullpage bulk file uploader

### DIFF
--- a/ckanext/unaids/assets/BulkFileUploaderComponent.css
+++ b/ckanext/unaids/assets/BulkFileUploaderComponent.css
@@ -3,7 +3,24 @@
     margin-bottom: 35px;
 }
 
-#BulkFileUploaderComponent .dropzone {
+#BulkFileUploaderComponent .fullPageDropzone {
+    border: 3px dashed white;
+    border-radius: 3px;
+    padding: 5px;
+    margin: -8px;
+    margin-bottom: 10px;
+}
+
+#BulkFileUploaderComponent .fullPageDropzone.active {
+    border-color: #189de3;
+    background-color: #eaf6fd;
+}
+
+#BulkFileUploaderComponent .fullPageDropzone.active .resource-item {
+    background-color: transparent !important;
+}
+
+#BulkFileUploaderComponent .modalDropzone {
     text-align: center;
     padding: 20px;
     border-width: 3px;
@@ -12,6 +29,11 @@
     border-style: dashed;
     background-color: #fafafa;
     margin-bottom: 20px;
+}
+
+#BulkFileUploaderComponent .modalDropzone.active {
+    border-color: #189de3;
+    background-color: #eaf6fd;
 }
 
 #BulkFileUploaderComponent .table td {
@@ -30,4 +52,31 @@
 
 #BulkFileUploaderComponent .label-danger {
     padding: 5px;
+}
+
+#BulkFileUploaderComponent .drag-files-instructions-wrapper {
+    position: fixed;
+    width: 100%;
+    bottom: 0;
+    left: 0;
+    z-index: 10000;
+}
+
+#BulkFileUploaderComponent .drag-files-instructions {
+    width: 300px;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 0;
+    border-radius: 5px;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    padding: 10px;
+    background-color: #189de3;
+    box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+    text-align: center;
+}
+
+#BulkFileUploaderComponent .drag-files-instructions h3 {
+    margin: 0;
+    color: white;
 }

--- a/ckanext/unaids/assets/BulkFileUploaderComponent.css
+++ b/ckanext/unaids/assets/BulkFileUploaderComponent.css
@@ -4,7 +4,7 @@
 }
 
 #BulkFileUploaderComponent .fullPageDropzone {
-    border: 3px dashed white;
+    border: 3px dashed transparent;
     border-radius: 3px;
     padding: 5px;
     margin: -8px;

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/index.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/index.js
@@ -2,8 +2,11 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 import App from './src/App';
 
+const componentElementId = 'BulkFileUploaderComponent';
+const modalElementId = 'BulkFileUploaderComponentModal';
+
 const componentElement =
-  document.getElementById('BulkFileUploaderComponent');
+  document.getElementById(componentElementId);
 const getAttr = key => {
   const val = componentElement.getAttribute(`data-${key}`);
   return ['None', ''].includes(val) ? null : val;
@@ -24,15 +27,20 @@ const loadCkan = callback => {
   } else {
     callback();
   }
-}
+};
+const moveDatasetPageIntoDropzoneArea = () => {
+  var fragment = document.createDocumentFragment();
+  fragment.appendChild(document.getElementById('ContentToMoveInsideDropzone'));
+  document.getElementById('DropzoneContainer').appendChild(fragment);
+};
 
 loadCkan(() => {
-  return (
-    ReactDOM.render(
-      <App {...{
-        lfsServer, maxResourceSize, orgId, datasetName, defaultFields
-      }} />,
-      componentElement
-    )
-  )
+  ReactDOM.render(
+    <App {...{
+      modalElementId, lfsServer, maxResourceSize,
+      orgId, datasetName, defaultFields
+    }} />,
+    componentElement
+  );
+  moveDatasetPageIntoDropzoneArea();
 });

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/index.test.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/index.test.js
@@ -110,12 +110,22 @@ describe('test without network issues', () => {
     );
   });
   describe("test file uploads using drag and drop", () => {
-    test('successful uploads', async () =>
-      await testSuccessfulUpload('BulkFileUploaderComponent')
-    );
-    test('file too large', async () =>
-      await testUploadWithFileTooLarge('BulkFileUploaderComponent')
-    );
+    describe("test popup modal", () => {
+      test('successful uploads', async () =>
+        await testSuccessfulUpload('modalDropzone')
+      );
+      test('file too large', async () =>
+        await testUploadWithFileTooLarge('modalDropzone')
+      );
+    });
+    describe("test dataset page", () => {
+      test('successful uploads', async () =>
+        await testSuccessfulUpload('fullPageDropzone')
+      );
+      test('file too large', async () =>
+        await testUploadWithFileTooLarge('fullPageDropzone')
+      );
+    });
   });
 });
 

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
@@ -1,198 +1,29 @@
-import React, { useState, useEffect } from 'react';
-import { Promise } from 'bluebird';
-import axios from 'axios';
-import FileUploader from './FileUploader';
-import { Client } from 'giftless-client';
-import ProgressBar from './ProgressBar';
+import React, { useState } from 'react';
+import Modal from './Modal';
+import FileUploader, { dropzoneTypes } from './FileUploader';
 
-export default function App({ lfsServer, maxResourceSize, orgId, datasetName, defaultFields }) {
+export default function App(props) {
 
     const [pendingFiles, setPendingFiles] = useState([]);
     const [uploadInProgress, setUploadInProgress] = useState(false);
     const [uploadsComplete, setUploadsComplete] = useState(false);
     const [networkError, setNetworkError] = useState(false);
-
-    const setFileProgress = (pendingFileIndex, loaded, total) => {
-        let _pendingFiles = [...pendingFiles];
-        _pendingFiles[pendingFileIndex].progress = { loaded, total };
-        setPendingFiles(_pendingFiles);
-    }
-    const removeFileFromPendingFiles = index => {
-        let _pendingFiles = [...pendingFiles];
-        _pendingFiles.splice(index, 1)
-        setPendingFiles(_pendingFiles);
-    }
-    const handleNetworkError = (errorType, error) => {
-        setNetworkError(errorType);
-        console.error(error);
-    };
-
-    const getAuthToken = () =>
-        axios.post(
-            '/api/3/action/authz_authorize',
-            { scopes: `obj:${orgId}/${datasetName}/*:write` },
-            { withCredentials: true }
-        )
-            .then(res => res.data.result.token)
-            .catch(error => handleNetworkError(
-                ckan.i18n._('Authorisation Error'), error
-            ))
-    const uploadFile = (client, index, localFile, setFileProgress) =>
-        client.upload(
-            localFile, orgId, datasetName,
-            ({ loaded, total }) =>
-                setFileProgress(index, loaded, total + 1)
-        ).catch(error => handleNetworkError(
-            ckan.i18n._('File Upload Error'), error
-        ));
-    const createResource = localFile =>
-        axios.post(
-            '/api/3/action/resource_create',
-            {
-                package_id: datasetName,
-                url_type: 'upload',
-                name: localFile._descriptor.name,
-                sha256: localFile._computedHashes.sha256,
-                size: localFile._descriptor.size,
-                url: localFile._descriptor.name,
-                lfs_prefix: `${orgId}/${datasetName}`,
-                ...defaultFields
-            },
-            { withCredentials: true }
-        ).catch(error => handleNetworkError(
-            ckan.i18n._('Resource Create Error'), error
-        ));
-
-    const uploadFiles = () => {
-        setUploadInProgress(true);
-        Promise.mapSeries(pendingFiles, async (file, index) => {
-            if (networkError) return;
-            const authToken = await getAuthToken();
-            const client = new Client(lfsServer, authToken, ['basic']);
-            if (!file.error) {
-                const localFile = data.open(file);
-                setFileProgress(index, 0, 100);
-                await uploadFile(client, index, localFile, setFileProgress);
-                await createResource(localFile);
-                setFileProgress(index, 100, 100);
-            }
-        }).then(() => setUploadsComplete(true));
+    const updatedProps = {
+        ...props,
+        pendingFiles, setPendingFiles,
+        uploadInProgress, setUploadInProgress,
+        uploadsComplete, setUploadsComplete,
+        networkError, setNetworkError
     }
 
-    function PendingFilesTable() {
-        const label = (file, index) => (
-            <>
-                <div>
-                    <span>{file.name}</span>
-                    {!file.progress &&
-                        <i
-                            className="fa fa-close text-danger remove-file-btn"
-                            onClick={() => removeFileFromPendingFiles(index)}
-                        ></i>
-                    }
-                </div>
-                {file.error &&
-                    <p className="label label-danger">{file.error}</p>
-                }
-            </>
-        )
-        const progressBar = file => !file.error && file.progress &&
-            <ProgressBar uploadProgress={file.progress} />
-        return (
-            <table className="table">
-                <tbody>
-                    {pendingFiles.map((file, index) => (
-                        <tr key={index}>
-                            <td width={20}><i className="fa fa-file"></i></td>
-                            <td width={400}>{label(file, index)}</td>
-                            <td>{progressBar(file)}</td>
-                        </tr>
-                    ))}
-                </tbody>
-            </table>
-        )
-    }
-    function UploadButton() {
-        const classes = `btn btn-default ${!pendingFiles.length && 'disabled'}`;
-        return (
-            <button
-                type="button"
-                className={classes}
-                data-testid="UploadFilesButton"
-                onClick={pendingFiles.length ? uploadFiles : null}
-            >
-                <i className="fa fa-upload"></i>
-                {ckan.i18n._('Upload Files')}
-            </button>
-        )
-    }
-    function FinishUploadButton() {
-        const handleClick = () =>
-            window.location.replace(window.location.pathname)
-        return (
-            <button
-                type="button"
-                className="btn btn-default"
-                onClick={handleClick}
-            >
-                <i className="fa fa-check"></i>
-                {ckan.i18n._('Finish')}
-            </button>
-        )
-    }
-    const Header = (label, color, icon) => (
-        <h1 className={`text-center ${color}`}>
-            <i className={`fa ${icon}`}></i>
-            <span>{label}</span>
-        </h1>
+    return (
+        <>
+            <Modal {...{ ...updatedProps }} />
+            <FileUploader {...{
+                ...updatedProps,
+                dropzoneType: dropzoneTypes.fullPageDropzone
+            }} />
+        </>
     )
-
-    if (networkError) {
-        return (
-            <>
-                {Header(
-                    networkError,
-                    'text-danger',
-                    'fa-exclamation-triangle'
-                )}
-                <hr />
-                <h3 className="text-center">
-                    {ckan.i18n._('Please refresh this page and try again')}
-                </h3>
-            </>
-        )
-    } else if (uploadsComplete) {
-        return (
-            <>
-                {Header(
-                    'Uploads Complete',
-                    'text-success',
-                    'fa-check-circle'
-                )}
-                <PendingFilesTable />
-                <FinishUploadButton />
-            </>
-        )
-    } else if (uploadInProgress) {
-        return (
-            <>
-                {Header(
-                    'Uploading...',
-                    'text-muted',
-                    'fa-spinner fa-spin'
-                )}
-                <PendingFilesTable />
-                <UploadButton />
-            </>
-        )
-    } else {
-        return (
-            <>
-                <FileUploader {...{ maxResourceSize, setPendingFiles }} />
-                <PendingFilesTable />
-                <UploadButton />
-            </>
-        )
-    }
 
 }

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/FileUploader.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/FileUploader.js
@@ -1,45 +1,79 @@
 import React from 'react';
 import { useDropzone } from 'react-dropzone'
 
-export default function FileUploader({ maxResourceSize, setPendingFiles }) {
+export const dropzoneTypes = {
+    fullPageDropzone: 'fullPageDropzone',
+    modalDropzone: 'modalDropzone'
+}
 
-    const { getRootProps, getInputProps, open } = useDropzone({
+export default function FileUploader({ modalElementId, maxResourceSize, setPendingFiles, dropzoneType }) {
+
+    const openModalUsingJquery = () => {
+        if (dropzoneType === dropzoneTypes.fullPageDropzone) {
+            $(`#${modalElementId}`).modal('show');
+        }
+    }
+    const handleDropAccepted = files => {
+        setPendingFiles(prev => [...prev, ...files]);
+    };
+    const handleDropRejected = rejections => {
+        const errorMessage = rejection => {
+            if (JSON.stringify(rejection).includes('file-too-large')) {
+                return ckan.i18n._(`Error: Resources cannot be larger than ${maxResourceSize} megabytes.`);
+            } else {
+                console.warn('Unhandled dropzone error', rejection.errors);
+                return ckan.i18n._('Error: Unable To Load File.');
+            }
+        };
+        let rejectedFiled = rejections.map(rejection => {
+            let rejectedFile = rejection.file;
+            rejectedFile.error = errorMessage(rejection);
+            return rejectedFile;
+        });
+        setPendingFiles(prev => [...prev, ...rejectedFiled]);
+    };
+
+    const { getRootProps, getInputProps, open, isDragActive } = useDropzone({
         noClick: true,
         maxSize: maxResourceSize * 1000000,
-        onDropAccepted: React.useCallback(files => {
-            setPendingFiles(prev => [...prev, ...files]);
-        }),
-        onDropRejected: React.useCallback(rejections => {
-            const errorMessage = rejection => {
-                if (JSON.stringify(rejection).includes('file-too-large')) {
-                    return ckan.i18n._(`Error: Resources cannot be larger than ${maxResourceSize} megabytes.`);
-                } else {
-                    console.warn('Unhandled dropzone error', rejection.errors);
-                    return ckan.i18n._('Error: Unable To Load File.');
-                }
-            };
-            let rejectedFiled = rejections.map(rejection => {
-                let rejectedFile = rejection.file;
-                rejectedFile.error = errorMessage(rejection);
-                return rejectedFile;
-            });
-            setPendingFiles(prev => [...prev, ...rejectedFiled]);
-        }),
+        onDrop: React.useCallback(openModalUsingJquery),
+        onDropAccepted: React.useCallback(handleDropAccepted),
+        onDropRejected: React.useCallback(handleDropRejected),
     });
 
+    const className = [dropzoneType, isDragActive ? 'active' : ''].join(' ');
     return (
-        <div {...getRootProps({ className: 'dropzone' })} data-testid="BulkFileUploaderComponent">
-            <input {...getInputProps()} data-testid="BulkFileUploaderInput" />
-            <p>{ckan.i18n._('Drag & Drop files here to initiate bulk upload')}</p>
-            <div className="btn-group">
-                <button
-                    className="btn btn-success"
-                    onClick={open}
-                >
-                    <i className="fa fa-plus"></i>
-                    {ckan.i18n._('Add files')}
-                </button>
-            </div>
+        <div {...getRootProps({ className })} data-testid={dropzoneType}        >
+            {dropzoneType === dropzoneTypes.fullPageDropzone
+                ? (
+                    <>
+                        <div id="DropzoneContainer"></div>
+                        ({isDragActive &&
+                            <div className="drag-files-instructions-wrapper">
+                                <div className="drag-files-instructions">
+                                    <h3><i className="fa fa-upload"></i></h3>
+                                    <h3>{ckan.i18n._('Drop files to upload them')}</h3>
+                                </div>
+                            </div>
+                        })
+                    </>
+                )
+                : (
+                    <>
+                        <input {...getInputProps()} data-testid="BulkFileUploaderInput" />
+                        <p>{ckan.i18n._('Drag & Drop files here to upload')}</p>
+                        <div className="btn-group">
+                            <button
+                                className="btn btn-success"
+                                onClick={open}
+                            >
+                                <i className="fa fa-plus"></i>
+                                {ckan.i18n._('Add files')}
+                            </button>
+                        </div>
+                    </>
+                )
+            }
         </div>
     )
 

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/FileUploader.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/FileUploader.js
@@ -48,14 +48,14 @@ export default function FileUploader({ modalElementId, maxResourceSize, setPendi
                 ? (
                     <>
                         <div id="DropzoneContainer"></div>
-                        ({isDragActive &&
+                        {isDragActive &&
                             <div className="drag-files-instructions-wrapper">
                                 <div className="drag-files-instructions">
                                     <h3><i className="fa fa-upload"></i></h3>
                                     <h3>{ckan.i18n._('Drop files to upload them')}</h3>
                                 </div>
                             </div>
-                        })
+                        }
                     </>
                 )
                 : (

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/FileUploader.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/FileUploader.js
@@ -61,7 +61,7 @@ export default function FileUploader({ modalElementId, maxResourceSize, setPendi
                 : (
                     <>
                         <input {...getInputProps()} data-testid="BulkFileUploaderInput" />
-                        <p>{ckan.i18n._('Drag & Drop files here to upload')}</p>
+                        <p>{ckan.i18n._('Drop files here to upload them to the dataset')}</p>
                         <div className="btn-group">
                             <button
                                 className="btn btn-success"

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/Modal.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/Modal.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import ModalBody from './ModalBody';
+
+export default function Modal(props) {
+    return (
+        <div className="modal fade" id={props.modalElementId}>
+            <div className="modal-dialog" role="document">
+                <div className="modal-content">
+                    <div className="modal-header">
+                        <button type="button" className="close" data-dismiss="modal">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                        <h4 className="modal-title">{ckan.i18n._('Upload Resources')}</h4>
+                    </div>
+                    <div className="modal-body">
+                        <ModalBody {...props} />
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/ModalBody.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/ModalBody.js
@@ -1,0 +1,203 @@
+import React from 'react';
+import { Promise } from 'bluebird';
+import axios from 'axios';
+import FileUploader, { dropzoneTypes } from './FileUploader';
+import { Client } from 'giftless-client';
+import ProgressBar from './ProgressBar';
+
+export default function ModalBody({
+    modalElementId, lfsServer, maxResourceSize,
+    orgId, datasetName, defaultFields,
+    pendingFiles, setPendingFiles,
+    uploadInProgress, setUploadInProgress,
+    uploadsComplete, setUploadsComplete,
+    networkError, setNetworkError
+}) {
+
+    const setFileProgress = (pendingFileIndex, loaded, total) => {
+        let _pendingFiles = [...pendingFiles];
+        _pendingFiles[pendingFileIndex].progress = { loaded, total };
+        setPendingFiles(_pendingFiles);
+    }
+    const removeFileFromPendingFiles = index => {
+        let _pendingFiles = [...pendingFiles];
+        _pendingFiles.splice(index, 1)
+        setPendingFiles(_pendingFiles);
+    }
+    const handleNetworkError = (errorType, error) => {
+        setNetworkError(errorType);
+        console.error(error);
+    };
+
+    const getAuthToken = () =>
+        axios.post(
+            '/api/3/action/authz_authorize',
+            { scopes: `obj:${orgId}/${datasetName}/*:write` },
+            { withCredentials: true }
+        )
+            .then(res => res.data.result.token)
+            .catch(error => handleNetworkError(
+                ckan.i18n._('Authorisation Error'), error
+            ))
+    const uploadFile = (client, index, localFile, setFileProgress) =>
+        client.upload(
+            localFile, orgId, datasetName,
+            ({ loaded, total }) =>
+                setFileProgress(index, loaded, total + 1)
+        ).catch(error => handleNetworkError(
+            ckan.i18n._('File Upload Error'), error
+        ));
+    const createResource = localFile =>
+        axios.post(
+            '/api/3/action/resource_create',
+            {
+                package_id: datasetName,
+                url_type: 'upload',
+                name: localFile._descriptor.name,
+                sha256: localFile._computedHashes.sha256,
+                size: localFile._descriptor.size,
+                url: localFile._descriptor.name,
+                lfs_prefix: `${orgId}/${datasetName}`,
+                ...defaultFields
+            },
+            { withCredentials: true }
+        ).catch(error => handleNetworkError(
+            ckan.i18n._('Resource Create Error'), error
+        ));
+
+    const uploadFiles = () => {
+        setUploadInProgress(true);
+        Promise.mapSeries(pendingFiles, async (file, index) => {
+            if (networkError) return;
+            const authToken = await getAuthToken();
+            const client = new Client(lfsServer, authToken, ['basic']);
+            if (!file.error) {
+                const localFile = data.open(file);
+                setFileProgress(index, 0, 100);
+                await uploadFile(client, index, localFile, setFileProgress);
+                await createResource(localFile);
+                setFileProgress(index, 100, 100);
+            }
+        }).then(() => setUploadsComplete(true));
+    }
+
+    function PendingFilesTable() {
+        const label = (file, index) => (
+            <>
+                <div>
+                    <span>{file.name}</span>
+                    {!file.progress &&
+                        <i
+                            className="fa fa-close text-danger remove-file-btn"
+                            onClick={() => removeFileFromPendingFiles(index)}
+                        ></i>
+                    }
+                </div>
+                {file.error &&
+                    <p className="label label-danger">{file.error}</p>
+                }
+            </>
+        )
+        const progressBar = file => !file.error && file.progress &&
+            <ProgressBar uploadProgress={file.progress} />
+        return (
+            <table className="table">
+                <tbody>
+                    {pendingFiles.map((file, index) => (
+                        <tr key={index}>
+                            <td width={20}><i className="fa fa-file"></i></td>
+                            <td width={400}>{label(file, index)}</td>
+                            <td>{progressBar(file)}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        )
+    }
+    function UploadButton() {
+        const classes = `btn btn-default ${!pendingFiles.length && 'disabled'}`;
+        return (
+            <button
+                type="button"
+                className={classes}
+                data-testid="UploadFilesButton"
+                onClick={pendingFiles.length ? uploadFiles : null}
+            >
+                <i className="fa fa-upload"></i>
+                {ckan.i18n._('Upload Files')}
+            </button>
+        )
+    }
+    function FinishUploadButton() {
+        const handleClick = () =>
+            window.location.replace(window.location.pathname)
+        return (
+            <button
+                type="button"
+                className="btn btn-default"
+                onClick={handleClick}
+            >
+                <i className="fa fa-check"></i>
+                {ckan.i18n._('Finish')}
+            </button>
+        )
+    }
+    const Header = (label, color, icon) => (
+        <h1 className={`text-center ${color}`}>
+            <i className={`fa ${icon}`}></i>
+            <span>{label}</span>
+        </h1>
+    )
+
+    if (networkError) {
+        return (
+            <>
+                {Header(
+                    networkError,
+                    'text-danger',
+                    'fa-exclamation-triangle'
+                )}
+                <hr />
+                <h3 className="text-center">
+                    {ckan.i18n._('Please refresh this page and try again')}
+                </h3>
+            </>
+        )
+    } else if (uploadsComplete) {
+        return (
+            <>
+                {Header(
+                    'Uploads Complete',
+                    'text-success',
+                    'fa-check-circle'
+                )}
+                <PendingFilesTable />
+                <FinishUploadButton />
+            </>
+        )
+    } else if (uploadInProgress) {
+        return (
+            <>
+                {Header(
+                    'Uploading...',
+                    'text-muted',
+                    'fa-spinner fa-spin'
+                )}
+                <PendingFilesTable />
+                <UploadButton />
+            </>
+        )
+    } else {
+        return (
+            <>
+                <FileUploader {...{
+                    modalElementId, maxResourceSize, setPendingFiles,
+                    dropzoneType: dropzoneTypes.modalDropzone
+                }} />
+                <PendingFilesTable />
+                <UploadButton />
+            </>
+        )
+    }
+
+}

--- a/ckanext/unaids/react/jest/globals.js
+++ b/ckanext/unaids/react/jest/globals.js
@@ -23,3 +23,9 @@ global.data = {
     }
   })
 };
+
+// mock jquery
+global.$ = () => {
+  // bootstrap modal actions
+  return { modal: () => null }
+}

--- a/ckanext/unaids/tests/test_dataset_transfer.py
+++ b/ckanext/unaids/tests/test_dataset_transfer.py
@@ -11,7 +11,7 @@ from ckanext.unaids.dataset_transfer.logic import (
 )
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'unaids scheming_datasets versions')
+@pytest.mark.ckan_config('ckan.plugins', 'unaids scheming_datasets versions blob_storage')
 @pytest.mark.usefixtures('with_plugins')
 class TestDatasetTransfer(object):
 

--- a/ckanext/unaids/theme/templates/package/snippets/bulk_file_uploader.html
+++ b/ckanext/unaids/theme/templates/package/snippets/bulk_file_uploader.html
@@ -4,44 +4,9 @@
         <span> {{ _('Bulk Upload') }}</span>
     </h2>
     <div class="module-content">
-
         <button type="button" class="btn btn-success" data-toggle="modal" data-target="#BulkFileUploaderComponentModal">
             <i className="fa fa-plus"></i>
             <span>{{ _('Add files') }}</span>
         </button>
-
-        <div class="modal fade" id="BulkFileUploaderComponentModal">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                        <h4 class="modal-title">{{ _('Bulk Upload') }}</h4>
-                    </div>
-                    <div class="modal-body">
-                        {% asset 'ckanext-unaids/BulkFileUploaderComponentStyles' %}
-                        <div
-                            id="BulkFileUploaderComponent"
-                            data-lfsServer="{{ h.blob_storage_server_url() }}"
-                            data-maxResourceSize="{{ h.max_resource_size() }}"
-                            data-orgId="{{ pkg.organization.name }}"
-                            data-datasetName="{{ pkg.name }}"
-                            data-defaultFields="{{ h.bulk_file_uploader_default_fields() }}"
-                        >
-                            <span class="text-muted">{{ _('Loading') }}</span>
-                        </div>
-                        {% asset 'ckanext-unaids/BulkFileUploaderComponentScripts' %}  
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <script>
-            // fix https://stackoverflow.com/q/10636667/2068836
-            var modal = document.getElementById('BulkFileUploaderComponentModal');
-            document.body.appendChild(modal);
-        </script>
-
     </div>
 </section>

--- a/ckanext/unaids/theme/templates/scheming/package/read.html
+++ b/ckanext/unaids/theme/templates/scheming/package/read.html
@@ -1,0 +1,17 @@
+{% extends "package/read.html" %}
+
+{% block package_resources %}
+  {% asset 'ckanext-unaids/BulkFileUploaderComponentStyles' %}
+  <div
+      id="BulkFileUploaderComponent"
+      data-lfsServer="{{ h.blob_storage_server_url() }}"
+      data-maxResourceSize="{{ h.max_resource_size() }}"
+      data-orgId="{{ pkg.organization.name }}"
+      data-datasetName="{{ pkg.name }}"
+      data-defaultFields="{{ h.bulk_file_uploader_default_fields() }}"
+  ></div>
+  {% asset 'ckanext-unaids/BulkFileUploaderComponentScripts' %}
+  <div id="ContentToMoveInsideDropzone">
+    {{ super() }}
+  </div>
+{% endblock %}

--- a/ckanext/unaids/theme/templates/scheming/package/read.html
+++ b/ckanext/unaids/theme/templates/scheming/package/read.html
@@ -1,4 +1,4 @@
-{% extends "package/read.html" %}
+{% ckan_extends %}
 
 {% block package_resources %}
   {% asset 'ckanext-unaids/BulkFileUploaderComponentStyles' %}


### PR DESCRIPTION
# Before
The bulk file uploader was only accessible via the sidebar | A modal would then allow you to select files to upload as new resources
--- | ---
![image](https://user-images.githubusercontent.com/2634482/124908629-6e886400-dfe1-11eb-9ca6-8836e6bd7965.png)|![image](https://user-images.githubusercontent.com/2634482/124908849-aee7e200-dfe1-11eb-9473-8981a87051cf.png)


# After
You can now directly drag-and-drop files onto the page

|With schema |Without schema 
--- | ---
![image](https://user-images.githubusercontent.com/2634482/124908078-d2f6f380-dfe0-11eb-857c-07eb9a322c82.png)|![image](https://user-images.githubusercontent.com/2634482/124908234-020d6500-dfe1-11eb-8928-4c46c611ffbc.png)

This will then open the modal just like before with your files selected.

# Changes
- Added new dropzone above resources section of page
- Slightly nicer css on-hover in existing modal dropzone
- Nothing else has changed, there's just been a lot of code reorganising 