### PR TITLE
ADX-730 Hotfix for 500 error opening private dataset.

### DIFF
--- a/ckanext/unaids/helpers.py
+++ b/ckanext/unaids/helpers.py
@@ -117,7 +117,10 @@ def get_current_dataset_release(dataset_id, activity_id=None):
         activities = toolkit.get_action('package_activity_list')(
             context, {'id': dataset_id}
         )
-        activity_id = activities[0]['id']
+        if not activities:
+            return None
+        else:
+            activity_id = activities[0]['id']
     releases = toolkit.get_action('dataset_version_list')(
         context, {'dataset_id': dataset_id}
     )


### PR DESCRIPTION
This is a hotfix for ADX-730.  The issue is a minor issue that only appears when users are trying to edit private datasets that don't have activity streams.  These are a very small minority of datasets either created by someone with the API or created so long ago before the UI removed the public/private setting.

There is no test for the helper in question, and the fix is so minor and the bug occurs in such an edge case that I have deemed a catching test not worth my time at this point.  If someone else wanted to address this I have no issues with that.  