### PR TITLE
ADX-729 fix modal closing config

### DIFF
--- a/ckanext/unaids/assets/BulkFileUploaderComponent.css
+++ b/ckanext/unaids/assets/BulkFileUploaderComponent.css
@@ -40,10 +40,13 @@
     overflow-wrap: break-word;
 }
 
-#BulkFileUploaderComponent .remove-file-btn {
+#BulkFileUploaderComponent .remove-file-btn-active {
     cursor: pointer;
-    margin: 0;
-    margin-left: 5px;
+}
+
+#BulkFileUploaderComponent .remove-file-btn-disabled {
+    cursor: not-allowed;
+    opacity: 0.25;
 }
 
 #BulkFileUploaderComponent .fa {
@@ -81,7 +84,7 @@
     color: white;
 }
 
-#BulkFileUploaderComponent select{
+#BulkFileUploaderComponent select {
     width: 100%;
     border: 1px solid #ccc;
     border-radius: 3px

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/Modal.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/Modal.js
@@ -3,13 +3,17 @@ import ModalBody from './ModalBody';
 
 export default function Modal(props) {
     return (
-        <div className="modal fade" id={props.modalElementId}>
+        <div className="modal fade" id={props.modalElementId} data-backdrop="static" data-keyboard="false">
             <div className="modal-dialog" role="document">
                 <div className="modal-content">
                     <div className="modal-header">
-                        <button type="button" className="close" data-dismiss="modal">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        {!props.uploadsComplete &&
+                            (
+                                <button type="button" className="close" data-dismiss="modal">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                            )
+                        }
                         <h4 className="modal-title">{ckan.i18n._('Upload Resources')}</h4>
                     </div>
                     <div className="modal-body">

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/Modal.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/Modal.js
@@ -7,7 +7,7 @@ export default function Modal(props) {
             <div className="modal-dialog" role="document">
                 <div className="modal-content">
                     <div className="modal-header">
-                        {!props.uploadsComplete &&
+                        {!props.uploadsComplete && !props.uploadInProgress &&
                             (
                                 <button type="button" className="close" data-dismiss="modal">
                                     <span aria-hidden="true">&times;</span>

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/ModalBody.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/ModalBody.js
@@ -167,13 +167,11 @@ export default function ModalBody({
                                         : fileUploadActionSelector(file, index))
                                 }
                             </td>
-                            <td width={20}>
-                                {!file.progress &&
-                                    <i
-                                        className="fa fa-close text-danger remove-file-btn"
-                                        onClick={() => removeFileFromPendingFiles(index)}
-                                    ></i>
-                                }
+                            <td width={30}>
+                                <i
+                                    className={`fa fa-close remove-file-btn-${uploadInProgress ? 'disabled' : 'active text-danger'} `}
+                                    onClick={() => !uploadInProgress && removeFileFromPendingFiles(index)}
+                                ></i>
                             </td>
                         </tr>
                     ))}


### PR DESCRIPTION
# Problem
- After uploading files successfully, you can close the popup modal and drag/drop additional files. This is confusing as the file uploads have already completed so you shouldn't have been allowed to add additional files
- During the upload process you can also remove pending files which is bad UX as it isn't clear if that meant the file was uploaded or not in the backend.

# Solution
- Disable the ability to close the modal unless you specifically click the `x` button
- Only display the `x` button if uploads have not already been posted.
- If uploads have been posted, then hide the button to force the user to click the `Finish` button which refreshes the page and thereby resets the react component to it's clean state.
- The little `x` buttons next to each file have also been disabled while uploads are in progress for better UX too

Video demo: https://youtu.be/Oy24jRuuBWI