### PR TITLE
Adx 725 partial matching

### DIFF
--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/index.test.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/index.test.js
@@ -146,6 +146,87 @@ describe('test selecting if we want to update an existing resource or upload a n
       const selectLabel = JSON.parse(selectValue).optionLabel;
       expect(selectLabel).toEqual('Resource 1');
     });
+    test('if the filename is a close match " (1)"', async () => {
+      const existingCoreResources = [];
+      const existingExtraResources = [
+        {
+          id: 2,
+          name: 'Resource 2',
+          resource_type: 'resource_type 2',
+          url: 'http://example.com/example.csv'
+        },
+        {
+          id: 1,
+          name: 'Resource 1',
+          resource_type: 'resource_type 1',
+          url: 'http://example.com/anc_data_file (1).csv'
+        }
+      ];
+      const missingCoreResources = [];
+      await stageFileUpload(
+        existingCoreResources,
+        existingExtraResources,
+        missingCoreResources
+      );
+      const selectValue = screen
+        .getAllByTestId('uploadActionSelector')[0].value;
+      const selectLabel = JSON.parse(selectValue).optionLabel;
+      expect(selectLabel).toEqual('Resource 1');
+    });
+    test('if the filename is a close match "-35"', async () => {
+      const existingCoreResources = [];
+      const existingExtraResources = [
+        {
+          id: 2,
+          name: 'Resource 2',
+          resource_type: 'resource_type 2',
+          url: 'http://example.com/example.csv'
+        },
+        {
+          id: 1,
+          name: 'Resource 1',
+          resource_type: 'resource_type 1',
+          url: 'http://example.com/anc_data_file-35.csv'
+        }
+      ];
+      const missingCoreResources = [];
+      await stageFileUpload(
+        existingCoreResources,
+        existingExtraResources,
+        missingCoreResources
+      );
+      const selectValue = screen
+        .getAllByTestId('uploadActionSelector')[0].value;
+      const selectLabel = JSON.parse(selectValue).optionLabel;
+      expect(selectLabel).toEqual('Resource 1');
+    });
+    test('if the filename is a close match "(copy)"', async () => {
+      const existingCoreResources = [];
+      const existingExtraResources = [
+        {
+          id: 2,
+          name: 'Resource 2',
+          resource_type: 'resource_type 2',
+          url: 'http://example.com/example.csv'
+        },
+        {
+          id: 1,
+          name: 'Resource 1',
+          resource_type: 'resource_type 1',
+          url: 'http://example.com/anc_data_file (copy).csv'
+        }
+      ];
+      const missingCoreResources = [];
+      await stageFileUpload(
+        existingCoreResources,
+        existingExtraResources,
+        missingCoreResources
+      );
+      const selectValue = screen
+        .getAllByTestId('uploadActionSelector')[0].value;
+      const selectLabel = JSON.parse(selectValue).optionLabel;
+      expect(selectLabel).toEqual('Resource 1');
+    });
     test('if the filename does not match', async () => {
       const existingCoreResources = [];
       const existingExtraResources = [
@@ -167,6 +248,27 @@ describe('test selecting if we want to update an existing resource or upload a n
       const selectLabel = JSON.parse(selectValue).optionLabel;
       expect(selectLabel).toEqual('Extra Resource');
     });
+    test('if the filename extension changes', async () => {
+      const existingCoreResources = [];
+      const existingExtraResources = [
+        {
+          id: 1,
+          name: 'Resource 1',
+          resource_type: 'resource_type 1',
+          url: 'http://example.com/example.icsv'
+        }
+      ];
+      const missingCoreResources = [];
+      await stageFileUpload(
+        existingCoreResources,
+        existingExtraResources,
+        missingCoreResources
+      );
+      const selectValue = screen
+        .getAllByTestId('uploadActionSelector')[0].value;
+      const selectLabel = JSON.parse(selectValue).optionLabel;
+      expect(selectLabel).toEqual('Extra Resource');
+    });
     test('if the filename matches multiple existing files', async () => {
       const existingCoreResources = [];
       const existingExtraResources = [
@@ -174,13 +276,13 @@ describe('test selecting if we want to update an existing resource or upload a n
           id: 1,
           name: 'Resource 1',
           resource_type: 'resource_type 1',
-          url: 'http://example.com/anc_data_file.csv'
+          url: 'http://example.com/anc_data_file(2).csv'
         },
         {
           id: 2,
           name: 'Resource 2',
           resource_type: 'resource_type 2',
-          url: 'http://example.com/anc_data_file.csv'
+          url: 'http://example.com/anc_data_file-1.csv'
         }
       ];
       const missingCoreResources = [];
@@ -195,7 +297,6 @@ describe('test selecting if we want to update an existing resource or upload a n
       expect(selectLabel).toEqual('Extra Resource');
     });
   });
-
   test('correct select option labels', async () => {
     const existingCoreResources = [
       {
@@ -429,4 +530,3 @@ describe('test with ckan authz_authorize network error', () => {
     await screen.findByText('Resource Create Error');
   })
 });
-

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
@@ -67,19 +67,22 @@ export default function App(props) {
         }
 
         function filenameMatch(filename1, filename2){
-            /* Matches where filenames begin and end with the same three (or more chars) and
-               any middle non-matching parts consist only of the following inserted or swapped:
+            /* Matches where filenames begin and end with the same three (or more chars),
+               have the same file extension, and any middle non-matching parts
+               consist only of the following inserted or swapped:
                - a number
                - a number in parenthesis
                - a number after a hyphen
             */
-            const regexp = /^$|^[\(-]? ?[0-9]*\)?$/;
+
+            const regexp = /^$|^ ?[\(-]? ?([0-9]|copy|Copy)*\)?$/;
             const matches = strDiff(filename1, filename2);
-            const completeMatch = matches[0] == matches[1] && matches[0];
+            const completeMatch = filename1 == filename2;
             const openingMatch = matches[0].length >= 3;
             const closingMatch = matches[1].length >= 3;
+            const extensionMatch = matches[1].includes('.');
             const regexMatch = matches[2].match(regexp) != null && matches[3].match(regexp) != null;
-            const match = completeMatch || openingMatch && closingMatch && regexMatch;
+            const match = completeMatch || openingMatch && closingMatch && extensionMatch && regexMatch;
             return match;
         }
 

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
@@ -40,38 +40,65 @@ export default function App(props) {
     const [networkError, setNetworkError] = useState(false);
 
     const getDefaultUploadAction = file => {
-        // disabled until we figure out a nicer algorithm
-        // const fuzzySearchResults = new Fuse(
-        //     updateResourcesOptions,
-        //     {
-        //         // https://bit.ly/3BTLnWd
-        //         includeScore: true,
-        //         findAllMatches: false,
-        //         keys: ['fileName'],
-        //         threshold: 0.3
-        //     }
-        // ).search(file.name);
-        // let defaultUploadAction = extraResource;
-        // if (fuzzySearchResults.length === 1) {
-        //     defaultUploadAction = fuzzySearchResults[0].item;
-        // } else if (fuzzySearchResults.length > 1) {
-        //     const firstResult = fuzzySearchResults[0];
-        //     const secondResult = fuzzySearchResults[1];
-        //     const scroreDiff = firstResult.score - secondResult.score;
-        //     if (scroreDiff > 0.05) {
-        //         defaultUploadAction = fuzzySearchResults[0].item;
-        //     }
-        // }
-        // return defaultUploadAction;
-        const exactMatches = updateResourcesOptions.filter(
-            x => x.fileName === file.name
-        );
-        switch (exactMatches.length) {
-            case 1:
-                return exactMatches[0];
-            default:
-                return extraResource;
+
+        function strDiff(str1, str2){
+            // Get all chars that match at the start of both strings
+            var openingMatch = "";
+            for(let x = 0; x < str1.length; x++){
+                if(str1.charAt(x) == str2.charAt(x)) openingMatch += str1.charAt(x);
+                else break;
+            }
+
+            // Get all chars that match at the end of both strings
+            var str1Reversed = str1.split("").reverse().join("");
+            var str2Reversed = str2.split("").reverse().join("");
+            var endingMatch = "";
+            for(let x = 0; x < str1.length; x++){
+                if(str1Reversed.charAt(x) == str2Reversed.charAt(x)) endingMatch += str1Reversed.charAt(x);
+                else break;
+            }
+            endingMatch = endingMatch.split("").reverse().join("");
+
+            // Get the middle non-matching part of each string
+            var str1Difference = str1.slice(openingMatch.length, str1.length-endingMatch.length).trim();
+            var str2Difference = str2.slice(openingMatch.length, str2.length-endingMatch.length)
+
+            return [openingMatch, endingMatch, str1Difference, str2Difference];
         }
+
+        function filenameMatch(filename1, filename2){
+            /* Matches where filenames begin and end with the same three (or more chars) and
+               any middle non-matching parts consist only of the following inserted or swapped:
+               - a number
+               - a number in parenthesis
+               - a number after a hyphen
+            */
+            const regexp = /^$|^[\(-]? ?[0-9]*\)?$/;
+            const matches = strDiff(filename1, filename2);
+            const completeMatch = matches[0] == matches[1] && matches[0];
+            const openingMatch = matches[0].length >= 3;
+            const closingMatch = matches[1].length >= 3;
+            const regexMatch = matches[2].match(regexp) != null && matches[3].match(regexp) != null;
+            const match = completeMatch || openingMatch && closingMatch && regexMatch;
+            return match;
+        }
+
+        // Find all matched resources
+        var matchedResources = []
+        for(let x = 0; x<updateResourcesOptions.length; x++){
+            if(filenameMatch(file.name, updateResourcesOptions[x].fileName)){
+                matchedResources.push(updateResourcesOptions[x]);
+            }
+        }
+
+        // Set the default upload action only if there is a single matching resource
+        var defaultUploadAction = extraResource;
+        if(matchedResources.length == 1){
+            defaultUploadAction = matchedResources[0];
+        }
+
+        return defaultUploadAction;
+
     }
 
     const updatedProps = {

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
@@ -41,32 +41,38 @@ export default function App(props) {
 
     const getDefaultUploadAction = file => {
 
-        function strDiff(str1, str2){
+        const strDiff = (str1, str2) => {
             // Get all chars that match at the start of both strings
-            var openingMatch = "";
+            let openingMatch = "";
             for(let x = 0; x < str1.length; x++){
-                if(str1.charAt(x) == str2.charAt(x)) openingMatch += str1.charAt(x);
-                else break;
+                if(str1.charAt(x) === str2.charAt(x)){
+                    openingMatch += str1.charAt(x);
+                } else {
+                    break;
+                }
             }
 
             // Get all chars that match at the end of both strings
-            var str1Reversed = str1.split("").reverse().join("");
-            var str2Reversed = str2.split("").reverse().join("");
-            var endingMatch = "";
+            let str1Reversed = str1.split("").reverse().join("");
+            let str2Reversed = str2.split("").reverse().join("");
+            let endingMatch = "";
             for(let x = 0; x < str1.length; x++){
-                if(str1Reversed.charAt(x) == str2Reversed.charAt(x)) endingMatch += str1Reversed.charAt(x);
-                else break;
+                if(str1Reversed.charAt(x) === str2Reversed.charAt(x)){
+                    endingMatch += str1Reversed.charAt(x);
+                } else {
+                    break;
+                }
             }
             endingMatch = endingMatch.split("").reverse().join("");
 
             // Get the middle non-matching part of each string
-            var str1Difference = str1.slice(openingMatch.length, str1.length-endingMatch.length).trim();
-            var str2Difference = str2.slice(openingMatch.length, str2.length-endingMatch.length)
+            let str1Difference = str1.slice(openingMatch.length, str1.length-endingMatch.length).trim();
+            let str2Difference = str2.slice(openingMatch.length, str2.length-endingMatch.length)
 
             return [openingMatch, endingMatch, str1Difference, str2Difference];
         }
 
-        function filenameMatch(filename1, filename2){
+        const filenameMatch = (filename1, filename2) => {
             /* Matches where filenames begin and end with the same three (or more chars),
                have the same file extension, and any middle non-matching parts
                consist only of the following inserted or swapped:
@@ -77,17 +83,17 @@ export default function App(props) {
 
             const regexp = /^$|^ ?[\(-]? ?([0-9]|copy|Copy)*\)?$/;
             const matches = strDiff(filename1, filename2);
-            const completeMatch = filename1 == filename2;
+            const completeMatch = filename1 === filename2;
             const openingMatch = matches[0].length >= 3;
             const closingMatch = matches[1].length >= 3;
             const extensionMatch = matches[1].includes('.');
             const regexMatch = matches[2].match(regexp) != null && matches[3].match(regexp) != null;
-            const match = completeMatch || openingMatch && closingMatch && extensionMatch && regexMatch;
+            const match = completeMatch || (openingMatch && closingMatch && extensionMatch && regexMatch);
             return match;
         }
 
         // Find all matched resources
-        var matchedResources = []
+        let matchedResources = []
         for(let x = 0; x<updateResourcesOptions.length; x++){
             if(filenameMatch(file.name, updateResourcesOptions[x].fileName)){
                 matchedResources.push(updateResourcesOptions[x]);
@@ -95,8 +101,8 @@ export default function App(props) {
         }
 
         // Set the default upload action only if there is a single matching resource
-        var defaultUploadAction = extraResource;
-        if(matchedResources.length == 1){
+        let defaultUploadAction = extraResource;
+        if(matchedResources.length === 1){
             defaultUploadAction = matchedResources[0];
         }
 

--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/App.js
@@ -71,8 +71,8 @@ export default function App(props) {
                have the same file extension, and any middle non-matching parts
                consist only of the following inserted or swapped:
                - a number
-               - a number in parenthesis
-               - a number after a hyphen
+               - a number or the word "copy" in parenthesis
+               - a number or the word "copy" after a hyphen
             */
 
             const regexp = /^$|^ ?[\(-]? ?([0-9]|copy|Copy)*\)?$/;


### PR DESCRIPTION
On my holiday I got thinking a bit about the partial filename matching logic as I would love this little feature to work.  Here's what I came up with.

We compare two file names, a and b,  to see if they match:

If a and b are equal, they match.

If a and b both open with the same three or more chars, and close with the same 3 or more chars, and has the same filename extension then we do a regex match on the middle non-matching part. This reg ex will only allow the middle non-matching parts of each filename to consist of the following inserted or swapped:
  - a number
  - a number or the word "copy" in parenthesis
  - a number or the word "copy" after a hyphen

Providing that only one resource matches the new resource name following this logic we will propose the default action of overriding that one resource.   The principle here is to be explicit - it does not matter if things that would ideally be matched don't match, it does matter quite a bit if things that should not match do actually match.  

This code should address the problem of CKAN filename munging I believe (removing parenthesis and inserting hyphens)

The code is tested, appears to work, and I'm pretty happy with it now. 

HOWEVER(!) it has been a long time since I wrote any Javascript, and I am quite sure my style my be outdated and poor.  I welcome any suggested changes from @Manoj-nathwani to ensure this is some good quality Javascript. 
