### PR TITLE
ADX-752 Set the default restricted value as a custom field

### DIFF
--- a/ckanext/unaids/presets.json
+++ b/ckanext/unaids/presets.json
@@ -33,7 +33,7 @@
         "validators": "ignore_missing",
         "form_snippet": "restricted_fields.html",
         "display_snippet": "restricted_fields.html",
-        "default": "{\"level\": \"restricted\", \"allowed_users\": \"\", \"allowed_organizations\": \"unaids\"}",
+        "default_restricted": "{\"level\": \"restricted\", \"allowed_users\": \"\", \"allowed_organizations\": \"unaids\"}",
         "choices": [{
             "value": "restricted",
             "label": "Restricted to specified users and organizations"


### PR DESCRIPTION
The "default" field is a special field that comes with behaviour from the scheming extension we do not want in the specific case of restricted data. I have changed the `default` field to a custom name `restricted_default`.