### PR TITLE
ADX-766: hide BulkFileUploader for users without edit rights

### DIFF
--- a/ckanext/unaids/theme/templates/scheming/package/read.html
+++ b/ckanext/unaids/theme/templates/scheming/package/read.html
@@ -1,23 +1,25 @@
 {% ckan_extends %}
 
 {% block package_resources %}
-  {% set core_resources = h.get_core_resources(pkg) %}
-  {% set missing = h.get_missing_resources(pkg, schema) %}
-  {% set extra_resources = h.get_extra_resources(pkg) %}
-  {% asset 'ckanext-unaids/BulkFileUploaderComponentStyles' %}
-  <div
-      id="BulkFileUploaderComponent"
-      data-lfsServer="{{ h.blob_storage_server_url() }}"
-      data-maxResourceSize="{{ h.max_resource_size() }}"
-      data-orgId="{{ pkg.organization.name }}"
-      data-datasetName="{{ pkg.name }}"
-      data-defaultFields="{{ h.bulk_file_uploader_default_fields() }}"
-      data-existingCoreResources="{{ core_resources|json_dumps|replace('"', '\"') }}"
-      data-existingExtraResources="{{ extra_resources|json_dumps|replace('"', '\"') }}"
-      data-missingCoreResources="{{ missing|json_dumps|replace('"', '\"') }}"
-  ></div>
-  {% asset 'ckanext-unaids/BulkFileUploaderComponentScripts' %}
-  <div id="ContentToMoveInsideDropzone">
-    {{ super() }}
-  </div>
+  {% if h.check_access('package_update') %}
+    {% set core_resources = h.get_core_resources(pkg) %}
+    {% set missing = h.get_missing_resources(pkg, schema) %}
+    {% set extra_resources = h.get_extra_resources(pkg) %}
+    {% asset 'ckanext-unaids/BulkFileUploaderComponentStyles' %}
+    <div
+        id="BulkFileUploaderComponent"
+        data-lfsServer="{{ h.blob_storage_server_url() }}"
+        data-maxResourceSize="{{ h.max_resource_size() }}"
+        data-orgId="{{ pkg.organization.name }}"
+        data-datasetName="{{ pkg.name }}"
+        data-defaultFields="{{ h.bulk_file_uploader_default_fields() }}"
+        data-existingCoreResources="{{ core_resources|json_dumps|replace('"', '\"') }}"
+        data-existingExtraResources="{{ extra_resources|json_dumps|replace('"', '\"') }}"
+        data-missingCoreResources="{{ missing|json_dumps|replace('"', '\"') }}"
+    ></div>
+    {% asset 'ckanext-unaids/BulkFileUploaderComponentScripts' %}
+    <div id="ContentToMoveInsideDropzone">
+      {{ super() }}
+    </div>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Hide the BulkFileUploader for users who do not have edit access

# Important
- This is untested code
- I don't have a functioning local stack so someone will need to check it.