### PR TITLE
ADX-769 Validation error message formats as lists.

### DIFF
--- a/ckanext/unaids/logic.py
+++ b/ckanext/unaids/logic.py
@@ -9,7 +9,7 @@ def validate_resource_upload_fields(context, resource_dict):
     no_upload_fields_present = not any([upload_has_sha256, upload_has_lfs_prefix, upload_has_size])
     if not valid_blob_storage_upload:
         raise toolkit.ValidationError(
-            "Invalid blob storage upload fields. sha256, size and lfs_prefix needs to be provided.")
+            ["Invalid blob storage upload fields. sha256, size and lfs_prefix needs to be provided."])
     elif no_upload_fields_present:
         return None
     else:
@@ -19,4 +19,4 @@ def validate_resource_upload_fields(context, resource_dict):
             toolkit.get_validator('valid_sha256')(sha256)
             toolkit.get_validator('valid_lfs_prefix')(lfs_prefix)
         except toolkit.Invalid as err:
-            raise toolkit.ValidationError(err.error)
+            raise toolkit.ValidationError([err.error])


### PR DESCRIPTION
For resource validation validation error messages needs to be wrapped in a list. With this fix the UI looks like this:
![image](https://user-images.githubusercontent.com/30174560/144000498-4a7c52a9-1645-4d69-b2e7-2570846ce93c.png)
![image](https://user-images.githubusercontent.com/30174560/144000541-c6446a3e-a8fb-41fc-a8b9-9adfdc6eecea.png)
