### PR TITLE
ADX-792 Default giftless metadata included at page load. 

### DIFF
--- a/ckanext/unaids/logic.py
+++ b/ckanext/unaids/logic.py
@@ -6,7 +6,12 @@ def validate_resource_upload_fields(context, resource_dict):
     upload_has_lfs_prefix = "lfs_prefix" in resource_dict
     upload_has_size = "size" in resource_dict
     valid_blob_storage_upload = (upload_has_sha256 == upload_has_lfs_prefix == upload_has_size)
-    no_upload_fields_present = not any([upload_has_sha256, upload_has_lfs_prefix, upload_has_size])
+    no_upload_fields_present = not any([
+        resource_dict.get("sha256", ""),
+        resource_dict.get("lfs_prefix", ""),
+        resource_dict.get("size", "")
+    ])
+
     if not valid_blob_storage_upload:
         raise toolkit.ValidationError(
             ["Invalid blob storage upload fields. sha256, size and lfs_prefix needs to be provided."])

--- a/ckanext/unaids/tests/test_logic.py
+++ b/ckanext/unaids/tests/test_logic.py
@@ -10,6 +10,8 @@ from ckanext.unaids import logic
     [
         ("fjelltopp/my-dataset", "acbac3b78f9ace071ca3a79f23fc788a1b7ee9dc547becc6404dbb1f58afff79", 100, True),
         (None, None, None, True),
+        ("", "", "", True),
+        (None, "", "", False),
         ("fjelltopp/my-dataset", "acbac3b78f9ace071ca3a79f23fc788a1b7ee9dc547becc6404dbb1f58afff79", None, False),
         (None, None, 100, False),
         ("fjelltopp/my-dataset", "", 100, False),
@@ -22,6 +24,8 @@ from ckanext.unaids import logic
     ], ids=[
         "validates if all upload fields correct",
         "validates if no upload fields present",
+        "validates if all fields are present but empty",
+        "fails if some fields missing and others set to empty string",
         "fails if size None",
         "fails if only size present",
         "fails if sha256 empty string",

--- a/ckanext/unaids/theme/templates/scheming/form_snippets/upload.html
+++ b/ckanext/unaids/theme/templates/scheming/form_snippets/upload.html
@@ -19,6 +19,13 @@
             <h3 class="text-muted">
                 <span><i class="fa fa-spinner fa-spin"></i> {{ _('Loading') }}</span>
             </h3>
+
+            <input name="url" data-testid="url" type="hidden" value="{{ data.url }}">
+            <input name="url_type" data-testid="url_type" type="hidden" value="{{ data.url_type }}">
+            <input name="lfs_prefix" data-testid="lfs_prefix" type="hidden" value="{{ data.lfs_prefix }}">
+            <input name="sha256" data-testid="sha256" type="hidden" value="{{ data.sha256 }}">
+            <input name="size" data-testid="size" type="hidden" value="{{ data.size }}">
+
         {% else %}
             <div>
                 <label class="control-label">{{ _('URL')}}</label>
@@ -40,11 +47,6 @@
         </div>
     {% endif %}
 
-    <input name="url" data-testid="url" type="hidden" value="{{ data.url if data else '' }}">
-    <input name="url_type" data-testid="url_type" type="hidden" value="{{ data.url_type if data else '' }}">
-    <input name="lfs_prefix" data-testid="lfs_prefix" type="hidden" value="{{ data.lfs_prefix if data else '' }}">
-    <input name="sha256" data-testid="sha256" type="hidden" value="{{ data.sha256 if data else '' }}">
-    <input name="size" data-testid="size" type="hidden" value="{{ data.size if data else '' }}">
 
 </div>
 

--- a/ckanext/unaids/theme/templates/scheming/form_snippets/upload.html
+++ b/ckanext/unaids/theme/templates/scheming/form_snippets/upload.html
@@ -13,7 +13,7 @@
     data-existingSha256="{{ data.sha256 if data else '' }}"
     data-existingFileName="{{ h.blob_storage_resource_filename(data) if data else '' }}"
     data-existingSize="{{ data.size if data else '' }}"
->       
+>
     {% if data.url %}
         {% if data.url_type == 'upload' %}
             <h3 class="text-muted">
@@ -37,8 +37,15 @@
     {% else %}
         <div class="dropzone text-muted">
             <h3><i class="fa fa-spinner fa-spin"></i> {{ _('Loading') }}</h3>
-        </div>        
+        </div>
     {% endif %}
+
+    <input name="url" data-testid="url" type="hidden" value="{{ data.url if data else '' }}">
+    <input name="url_type" data-testid="url_type" type="hidden" value="{{ data.url_type if data else '' }}">
+    <input name="lfs_prefix" data-testid="lfs_prefix" type="hidden" value="{{ data.lfs_prefix if data else '' }}">
+    <input name="sha256" data-testid="sha256" type="hidden" value="{{ data.sha256 if data else '' }}">
+    <input name="size" data-testid="size" type="hidden" value="{{ data.size if data else '' }}">
+
 </div>
 
 {% asset 'ckanext-unaids/FileInputComponentScripts' %}


### PR DESCRIPTION
Problem: users have edited and saved metadata in less than the time it takes for the FileInputComponent to load.  This has meant that the giftless metadata, which is added to the form submission by the file input component, was lost. 

Possible solutions:

- Delay form submission until the file input component had properly loaded
- Ensure that the relevant information is supplied as part of the page HTML, so that the form can be used even if the FileInputComponent entirely fails to load.

I have pursued the second option, as this is how we are approaching the matter everywhere else in the CKAN UI; the HTML responsible for the giftless metadata that is created/updated by the FileInputComponent react code is now initialised by the server upon page load. I've used Chrome request throttling to test it works in my UI.  Without a proper UI testing framework it is hard to write a regression test. 