### PR TITLE
ADX-279 Add API action user_show_me

### DIFF
--- a/ckanext/unaids/actions.py
+++ b/ckanext/unaids/actions.py
@@ -170,3 +170,12 @@ def format_guess(context, data_dict):
         return {'mimetype': mimetype, 'format': format}
     else:
         return {'mimetype': None, 'format': None}
+
+
+@logic.side_effect_free
+def user_show_me(context, resource_dict):
+    auth_user_obj = context.get('auth_user_obj')
+    if auth_user_obj:
+        return auth_user_obj.as_dict()
+    else:
+        return {}

--- a/ckanext/unaids/actions.py
+++ b/ckanext/unaids/actions.py
@@ -11,6 +11,7 @@ from ckan.common import _
 from ckanext.versions.logic.dataset_version_action import get_activity_id_from_dataset_version_name, activity_dataset_show
 
 NotFound = logic.NotFound
+NotAuthorized = logic.NotAuthorized
 _check_access = logic.check_access
 _validate = dfunc.validate
 ValidationError = logic.ValidationError
@@ -203,4 +204,4 @@ def user_show_me(context, resource_dict):
     if auth_user_obj:
         return auth_user_obj.as_dict()
     else:
-        return {}
+        raise NotAuthorized

--- a/ckanext/unaids/actions.py
+++ b/ckanext/unaids/actions.py
@@ -176,12 +176,13 @@ def format_guess(context, data_dict):
 @logic.side_effect_free
 def user_show_me(context, resource_dict):
     """
-    Returns the current user object.
+    Returns the current user object.  Raises NotAuthorized error if no user
+    object found.
 
     No input params.
 
-    :rtype: Empty dict if no user (invalid authentication), otherwise the user
-        object as a dictionary, which takes the following structure:
+    :rtype dictionary
+    :returns The user object as a dictionary, which takes the following structure:
         ```
             {
                 "id": "7f88caf3-e68b-4c96-883e-b49f3d547d84",

--- a/ckanext/unaids/actions.py
+++ b/ckanext/unaids/actions.py
@@ -174,6 +174,31 @@ def format_guess(context, data_dict):
 
 @logic.side_effect_free
 def user_show_me(context, resource_dict):
+    """
+    Returns the current user object.
+
+    No input params.
+
+    :rtype: Empty dict if no user (invalid authentication), otherwise the user
+        object as a dictionary, which takes the following structure:
+        ```
+            {
+                "id": "7f88caf3-e68b-4c96-883e-b49f3d547d84",
+                "name": "fjelltopp_editor",
+                "fullname": "Fjelltopp Editor",
+                "email": "fjelltopp_editor@fjelltopp.org",
+                "created": "2021-10-29 12:51:56.277305",
+                "reset_key": null,
+                "about": null,
+                "activity_streams_email_notifications": false,
+                "sysadmin": false,
+                "state": "active",
+                "image_url": null,
+                "plugin_extras": null
+            }
+        ```
+
+    """
     auth_user_obj = context.get('auth_user_obj')
     if auth_user_obj:
         return auth_user_obj.as_dict()

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -101,7 +101,8 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
             u'get_table_schema': actions.get_table_schema,
             u'package_show': actions.dataset_version_show,
             u'package_activity_list': actions.package_activity_list,
-            u'format_guess': actions.format_guess
+            u'format_guess': actions.format_guess,
+            u'user_show_me': actions.user_show_me
         }
 
     def dataset_facets(self, facet_dict, package_type):

--- a/ckanext/unaids/tests/test_actions.py
+++ b/ckanext/unaids/tests/test_actions.py
@@ -3,6 +3,7 @@
 from ckan.plugins import toolkit
 from ckan.tests.helpers import call_action
 from ckan.tests import factories
+import ckan.model as model
 import pytest
 import logging
 from pprint import pformat
@@ -175,3 +176,18 @@ class TestFormatGuess(object):
         response = call_action('format_guess', {}, filename=filename)
         assert response.get('mimetype') == mimetype
         assert response.get('format') == format
+
+
+@pytest.mark.ckan_config('ckan.plugins', 'unaids')
+@pytest.mark.usefixtures('with_plugins')
+class TestUserShowMe(object):
+
+    def test_no_user(self):
+        response = call_action('user_show_me', {})
+        assert not response
+
+    def test_user(self):
+        user = factories.User()
+        user_obj = model.User.get(user['name'])
+        response = call_action('user_show_me', {'auth_user_obj': user_obj})
+        assert response['name'] == user['name']

--- a/ckanext/unaids/tests/test_actions.py
+++ b/ckanext/unaids/tests/test_actions.py
@@ -3,6 +3,7 @@
 from ckan.plugins import toolkit
 from ckan.tests.helpers import call_action
 from ckan.tests import factories
+from ckan.logic import NotAuthorized
 import ckan.model as model
 import pytest
 import logging
@@ -183,8 +184,8 @@ class TestFormatGuess(object):
 class TestUserShowMe(object):
 
     def test_no_user(self):
-        response = call_action('user_show_me', {})
-        assert not response
+        with pytest.raises(NotAuthorized):
+            call_action('user_show_me', {})
 
     def test_user(self):
         user = factories.User()


### PR DESCRIPTION
Adds a new API action that simply returns the current user obj.  Can be used to verify if an API key is valid. Tests included.

Is there a security concern around this endpoint?  Should we throttle the number of times someone can call it?
