### PR TITLE
ADX-789 Link to portugese translations of instructional pages

### DIFF
--- a/ckanext/unaids/theme/templates/home/layout1.html
+++ b/ckanext/unaids/theme/templates/home/layout1.html
@@ -35,6 +35,9 @@
         {% if h.lang() == 'fr' %}
           {% set inputs_page = 'fr-inputs-unaids' %}
           {% set vmmc_page = 'fr-vmmc' %}
+        {% elif h.lang() == 'pt_PT' %}
+          {% set inputs_page = 'pt-inputs-unaids' %}
+          {% set vmmc_page = 'pt-vmmc' %}
         {% else %}
           {% set inputs_page = 'inputs-unaids' %}
           {% set vmmc_page = 'vmmc' %}


### PR DESCRIPTION
A tiny change to enable UNAIDS to translate the instructional pages linked to from the home page.  I've carefully checked it all works locally.