### PR TITLE
ADX-470 data dictionaries

### DIFF
--- a/ckanext/unaids/actions.py
+++ b/ckanext/unaids/actions.py
@@ -9,7 +9,7 @@ import ckan.plugins.toolkit as t
 import ckanext.validation.helpers as validation_helpers
 from ckan.common import _
 from ckanext.versions.logic.dataset_version_action import get_activity_id_from_dataset_version_name, activity_dataset_show
-from ckanext.unaids.logic import auto_populate_data_dictionary
+from ckanext.unaids.logic import populate_data_dictionary_from_schema
 
 NotFound = logic.NotFound
 NotAuthorized = logic.NotAuthorized
@@ -215,4 +215,4 @@ def populate_data_dictionary(context, data_dict):
         context,
         {'id': resource_id}
     )
-    auto_populate_data_dictionary(context, resource_dict)
+    populate_data_dictionary_from_schema(context, resource_dict)

--- a/ckanext/unaids/actions.py
+++ b/ckanext/unaids/actions.py
@@ -206,3 +206,11 @@ def user_show_me(context, resource_dict):
         return auth_user_obj.as_dict()
     else:
         raise NotAuthorized
+
+
+def populate_data_dictionary(context, data_dict):
+    resource_dict = t.get_action('resource_show')(
+        context,
+        {'id': data_dict['resource_id']}
+    )
+    logic.populate_data_dictionary(context, resource_dict)

--- a/ckanext/unaids/actions.py
+++ b/ckanext/unaids/actions.py
@@ -210,9 +210,9 @@ def user_show_me(context, resource_dict):
 
 
 def populate_data_dictionary(context, data_dict):
-
+    resource_id = logic.get_or_bust(data_dict, 'resource_id')
     resource_dict = t.get_action('resource_show')(
         context,
-        {'id': data_dict['resource_id']}
+        {'id': resource_id}
     )
     auto_populate_data_dictionary(context, resource_dict)

--- a/ckanext/unaids/actions.py
+++ b/ckanext/unaids/actions.py
@@ -9,6 +9,7 @@ import ckan.plugins.toolkit as t
 import ckanext.validation.helpers as validation_helpers
 from ckan.common import _
 from ckanext.versions.logic.dataset_version_action import get_activity_id_from_dataset_version_name, activity_dataset_show
+from ckanext.unaids.logic import auto_populate_data_dictionary
 
 NotFound = logic.NotFound
 NotAuthorized = logic.NotAuthorized
@@ -209,8 +210,9 @@ def user_show_me(context, resource_dict):
 
 
 def populate_data_dictionary(context, data_dict):
+
     resource_dict = t.get_action('resource_show')(
         context,
         {'id': data_dict['resource_id']}
     )
-    logic.populate_data_dictionary(context, resource_dict)
+    auto_populate_data_dictionary(context, resource_dict)

--- a/ckanext/unaids/logic.py
+++ b/ckanext/unaids/logic.py
@@ -68,7 +68,8 @@ def auto_populate_data_dictionary(context, resource_dict):
     for field in fields:
         field_id = field[u'id']
 
-        if field_id in field_schemas and not field.get(u'info'):
+        if field_id in field_schemas:
+
             field[u'info'] = {
                 u'label': field_schemas[field_id].get(u'title', field_id),
                 u'notes': field_schemas[field_id].get(u'description', field_id)

--- a/ckanext/unaids/logic.py
+++ b/ckanext/unaids/logic.py
@@ -38,12 +38,8 @@ def update_filename_in_resource_url(resource):
     return resource
 
 
-def auto_populate_data_dictionary(context, resource_dict):
-    table_schema_name = resource_dict.get('schema')
-
-    if not table_schema_name:
-        return
-
+def populate_data_dictionary_from_schema(context, resource_dict):
+    table_schema_name = toolkit.get_or_bust(resource_dict, 'schema')
     table_schema = validation_load_json_schema(table_schema_name)
 
     if not table_schema:
@@ -57,6 +53,7 @@ def auto_populate_data_dictionary(context, resource_dict):
         fields = toolkit.get_action(u'datastore_search')(
             context, {u'resource_id': resource_dict['id']}
         )[u'fields']
+
     except toolkit.ObjectNotFound:
         raise toolkit.ObjectNotFound(
             'Resource "{}" must first be uploaded to the datastore in order to '

--- a/ckanext/unaids/logic.py
+++ b/ckanext/unaids/logic.py
@@ -38,7 +38,7 @@ def update_filename_in_resource_url(resource):
     return resource
 
 
-def auto_populate_data_dictionary(context, resource_dict, dataset_dict):
+def auto_populate_data_dictionary(context, resource_dict):
     table_schema = resource_dict.get('schema')
 
     if not table_schema:
@@ -50,14 +50,19 @@ def auto_populate_data_dictionary(context, resource_dict, dataset_dict):
         return
 
     field_schemas = {field['name']: field for field in table_schema_dict['fields']}
-    fields = toolkit.get_action(u'datastore_search')(
-        context, {u'resource_id': resource_dict['id']}
-    )[u'fields']
+
+    try:
+        fields = toolkit.get_action(u'datastore_search')(
+            context, {u'resource_id': resource_dict['id']}
+        )[u'fields']
+    except toolkit.ObjectNotFound:
+        return
 
     fields = fields[1:]  # Hack: to get rid of _id field.  But this should be got rid of higher up stream.
 
     for field in fields:
         field_id = field[u'id']
+
         if field_id in field_schemas and not field.get(u'info'):
             field[u'info'] = {
                 u'label': field_schemas[field_id].get(u'title', field_id),

--- a/ckanext/unaids/logic.py
+++ b/ckanext/unaids/logic.py
@@ -46,19 +46,18 @@ def auto_populate_data_dictionary(context, resource_dict):
 
     table_schema_dict = validation_load_json_schema(table_schema)
 
-    if not table_schema_dict or not table_schema_dict.get('fields'):
-        return
+    if not table_schema_dict:
+        raise toolkit.ObjectNotFound(
+            'Table schema "{}" does not exist'.format(table_schema)
+        )
 
     field_schemas = {field['name']: field for field in table_schema_dict['fields']}
 
-    try:
-        fields = toolkit.get_action(u'datastore_search')(
-            context, {u'resource_id': resource_dict['id']}
-        )[u'fields']
-    except toolkit.ObjectNotFound:
-        return
+    fields = toolkit.get_action(u'datastore_search')(
+        context, {u'resource_id': resource_dict['id']}
+    )[u'fields']
 
-    fields = fields[1:]  # Hack: to get rid of _id field.  But this should be got rid of higher up stream.
+    fields = fields[1:]  # Hack: to get rid of _id field.
 
     for field in fields:
         field_id = field[u'id']

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -108,7 +108,8 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
             u'package_show': actions.dataset_version_show,
             u'package_activity_list': actions.package_activity_list,
             u'format_guess': actions.format_guess,
-            u'user_show_me': actions.user_show_me
+            u'user_show_me': actions.user_show_me,
+            u'populate_data_dictionary': actions.populate_data_dictionary
         }
 
     def dataset_facets(self, facet_dict, package_type):

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -197,13 +197,13 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
             return logic.update_filename_in_resource_url(resource)
 
     def after_upload(self, context, resource_dict, dataset_dict):
+        pass
+        # try:
+        #     logic.auto_populate_data_dictionary(context, resource_dict)
 
-        try:
-            logic.auto_populate_data_dictionary(context, resource_dict)
-
-        except Exception as e:
-            # Background task should fail silently otherwise problems downstream
-            log.exception(e)
+        # except Exception as e:
+        #     # Background task should fail silently otherwise problems downstream
+        #     log.exception(e)
 
 
 class UNAIDSReclineView(ReclineViewBase):

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -196,7 +196,13 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
             return logic.update_filename_in_resource_url(resource)
 
     def after_upload(self, context, resource_dict, dataset_dict):
-        logic.auto_populate_data_dictionary(context, resource_dict)
+
+        try:
+            logic.auto_populate_data_dictionary(context, resource_dict)
+
+        except Exception as e:
+            # Background task should fail silently otherwise problems downstream
+            log.exception(e)
 
 
 class UNAIDSReclineView(ReclineViewBase):

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -42,7 +42,6 @@ from ckanext.reclineview.plugin import ReclineViewBase
 from ckanext.validation.interfaces import IDataValidation
 from ckanext.unaids.dataset_transfer.logic import send_dataset_transfer_emails
 from ckanext.datapusher.interfaces import IDataPusher
-from ckanext.validation.helpers import validation_load_json_schema
 
 log = logging.getLogger(__name__)
 
@@ -76,11 +75,8 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
     p.implements(p.IValidators)
     p.implements(p.IActions)
     p.implements(IDataValidation)
-<<<<<<< HEAD
     p.implements(IResourceDownloadHandler, inherit=True)
-=======
     p.implements(IDataPusher, inherit=True)
->>>>>>> ADX-470 Initial working proof of concept
 
     # IClick
     def get_commands(self):
@@ -195,40 +191,12 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
             logic.validate_resource_upload_fields(context, resource)
         return resource
 
-
     def before_show(self, resource):
         if _data_dict_is_resource(resource):
             return logic.update_filename_in_resource_url(resource)
 
-
     def after_upload(self, context, resource_dict, dataset_dict):
-
-        table_schema = resource_dict.get('schema')
-        if table_schema:
-            table_schema_dict = validation_load_json_schema(table_schema)
-            field_schemas = {}
-            for field_schema in table_schema_dict['fields']:
-                field_schemas[field_schema['name']] = field_schema
-            fields = toolkit.get_action(u'datastore_search')(
-                None, {'resource_id': resource_dict['id']}
-            )['fields']
-            fields = fields[1:]  # Hack: to get rid of _id field.  But this should be got rid of higher up stream.
-
-            for index, field in enumerate(fields):
-                field_id = field['id']
-                if not field.get('info'):
-                    field['info'] = {
-                        'label': field_schemas[field_id].get('title', field_id),
-                        'notes': field_schemas[field_id].get('description', field_id)
-                    }
-
-            toolkit.get_action(u'datastore_create')(
-                None, {
-                    u'resource_id': resource_dict['id'],
-                    u'force': True,
-                    u'fields': fields
-                }
-            )
+        logic.auto_populate_data_dictionary(context, resource_dict, dataset_dict)
 
 
 class UNAIDSReclineView(ReclineViewBase):

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -196,7 +196,7 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
             return logic.update_filename_in_resource_url(resource)
 
     def after_upload(self, context, resource_dict, dataset_dict):
-        logic.auto_populate_data_dictionary(context, resource_dict, dataset_dict)
+        logic.auto_populate_data_dictionary(context, resource_dict)
 
 
 class UNAIDSReclineView(ReclineViewBase):

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -197,12 +197,16 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
             return logic.update_filename_in_resource_url(resource)
 
     def after_upload(self, context, resource_dict, dataset_dict):
-        try:
-            logic.auto_populate_data_dictionary(context, resource_dict)
-
-        except Exception as e:
-            # Background task should fail silently otherwise problems downstream
-            log.exception(e)
+        if 'schema' in resource_dict:
+            try:
+                logic.populate_data_dictionary_from_schema(context, resource_dict)
+            except Exception:
+                log.exception(
+                    "Error in background task auto populating {} data dictionary. "
+                    "Failing silently to avoid problems downstream".format(
+                        resource_dict.get('id', '')
+                    )
+                )
 
 
 class UNAIDSReclineView(ReclineViewBase):

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -197,13 +197,12 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
             return logic.update_filename_in_resource_url(resource)
 
     def after_upload(self, context, resource_dict, dataset_dict):
-        pass
-        # try:
-        #     logic.auto_populate_data_dictionary(context, resource_dict)
+        try:
+            logic.auto_populate_data_dictionary(context, resource_dict)
 
-        # except Exception as e:
-        #     # Background task should fail silently otherwise problems downstream
-        #     log.exception(e)
+        except Exception as e:
+            # Background task should fail silently otherwise problems downstream
+            log.exception(e)
 
 
 class UNAIDSReclineView(ReclineViewBase):

--- a/ckanext/unaids/tests/test_actions.py
+++ b/ckanext/unaids/tests/test_actions.py
@@ -8,7 +8,6 @@ import ckan.model as model
 import pytest
 import logging
 from pprint import pformat
-
 from ckanext.unaids.tests import get_context, create_dataset_with_releases
 
 log = logging.getLogger(__name__)
@@ -192,3 +191,21 @@ class TestUserShowMe(object):
         user_obj = model.User.get(user['name'])
         response = call_action('user_show_me', {'auth_user_obj': user_obj})
         assert response['name'] == user['name']
+
+
+@pytest.mark.ckan_config('ckan.plugins', 'unaids')
+@pytest.mark.usefixtures('with_plugins')
+class TestPopulateDataDictionary(object):
+
+    def test_expected_use(self, mocker):
+        context = {}
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            schema='test_schema'
+        )
+        mock_auto_populate_data_dictionary = mocker.patch(
+            'ckanext.unaids.actions.auto_populate_data_dictionary',
+        )
+        call_action('populate_data_dictionary', {}, resource_id=resource['id'])
+        mock_auto_populate_data_dictionary.assert_called_once_with(mocker.ANY, resource)

--- a/ckanext/unaids/tests/test_actions.py
+++ b/ckanext/unaids/tests/test_actions.py
@@ -198,7 +198,6 @@ class TestUserShowMe(object):
 class TestPopulateDataDictionary(object):
 
     def test_expected_use(self, mocker):
-        context = {}
         dataset = factories.Dataset()
         resource = factories.Resource(
             package_id=dataset['id'],

--- a/ckanext/unaids/tests/test_actions.py
+++ b/ckanext/unaids/tests/test_actions.py
@@ -201,10 +201,12 @@ class TestPopulateDataDictionary(object):
         dataset = factories.Dataset()
         resource = factories.Resource(
             package_id=dataset['id'],
-            schema='test_schema'
+            schema='test_schema',
+            url='some.data'
         )
-        mock_auto_populate_data_dictionary = mocker.patch(
-            'ckanext.unaids.actions.auto_populate_data_dictionary',
+
+        mock_populate_data_dictionary_from_schema = mocker.patch(
+            'ckanext.unaids.actions.populate_data_dictionary_from_schema',
         )
         call_action('populate_data_dictionary', {}, resource_id=resource['id'])
-        mock_auto_populate_data_dictionary.assert_called_once_with(mocker.ANY, resource)
+        mock_populate_data_dictionary_from_schema.assert_called_once_with(mocker.ANY, resource)

--- a/ckanext/unaids/tests/test_logic.py
+++ b/ckanext/unaids/tests/test_logic.py
@@ -3,7 +3,6 @@ import pytest
 from ckan.plugins import toolkit
 from ckan.tests import factories
 from ckanext.unaids import logic
-from ckan.tests import factories
 
 
 @pytest.mark.ckan_config('ckan.plugins', 'unaids authz_service blob_storage')

--- a/ckanext/unaids/tests/test_logic.py
+++ b/ckanext/unaids/tests/test_logic.py
@@ -140,7 +140,7 @@ class TestAutoPopulateDataDictionaries():
                 'fields': [
                     {'id': '_id', 'type': 'numeric'},
                     {'id': 'area_id', 'type': 'numeric'},
-                    {'id': 'area_name', 'type': 'text'},
+                    {'id': 'area_name', 'type': 'text', 'info': {'notes': 'Existing notes'}},
                 ]
             }
         )
@@ -177,8 +177,7 @@ class TestAutoPopulateDataDictionaries():
                     u'id': u'area_name',
                     u'type': u'text',
                     u'info': {
-                        u'label': u'Area Name',
-                        u'notes': u'Area name for area_id (optional).'
+                        u'notes': u'Existing notes'
                     }
                 }
             ]

--- a/ckanext/unaids/tests/test_logic.py
+++ b/ckanext/unaids/tests/test_logic.py
@@ -163,7 +163,8 @@ class TestAutoPopulateDataDictionaries():
                     u'id': u'area_name',
                     u'type': u'text',
                     u'info': {
-                        u'notes': u'Existing notes'
+                        u'label': u'Area Name',
+                        u'notes': u'Area name for area_id (optional).'
                     }
                 }
             ]

--- a/ckanext/unaids/tests/test_logic.py
+++ b/ckanext/unaids/tests/test_logic.py
@@ -3,6 +3,8 @@ import pytest
 from ckan.plugins import toolkit
 from ckan.tests import factories
 from ckanext.unaids import logic
+from ckan.tests import factories
+import ckan.logic
 
 
 @pytest.mark.ckan_config('ckan.plugins', 'unaids authz_service blob_storage')
@@ -62,3 +64,122 @@ def test_update_filename_in_resource_url():
                                   size=500
                                   )
     assert resource['url'].endswith(actual_filename)
+
+
+class TestAutoPopulateDataDictionaries():
+
+    def test_no_schema(self, mocker):
+        context = {}
+        dataset = factories.Dataset()
+        resource = factories.Resource(package_id=dataset['id'])
+        mock_load_json_schema = mocker.patch(
+            'ckanext.unaids.logic.validation_load_json_schema'
+        )
+        logic.auto_populate_data_dictionary(context, resource, dataset)
+        mock_load_json_schema.assert_not_called()
+
+    def test_missing_schema(self, mocker):
+        context = {}
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            schema='test_schema'
+        )
+        mock_load_json_schema = mocker.patch(
+            'ckanext.unaids.logic.validation_load_json_schema',
+            return_value=None
+        )
+        logic.auto_populate_data_dictionary(context, resource, dataset)
+        mock_load_json_schema.assert_called_once_with(u'test_schema')
+
+    def test_schema_missing_fields(self, mocker):
+        context = {}
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            schema='test_schema'
+        )
+        mock_load_json_schema = mocker.patch(
+            'ckanext.unaids.logic.validation_load_json_schema',
+            return_value={'title': 'Schema without fields'}
+        )
+        logic.auto_populate_data_dictionary(context, resource, dataset)
+        mock_load_json_schema.assert_called_once_with(u'test_schema')
+
+    def test_simple_schema(self, mocker):
+        context = {}
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            schema='test_schema'
+        )
+        mock_load_json_schema = mocker.patch(
+            'ckanext.unaids.logic.validation_load_json_schema',
+            return_value={
+                "title": "UNAIDS ART Programme Input",
+                "fields": [
+                    {
+                        "name": "area_id",
+                        "title": "Area ID",
+                        "description": "An area_id from the agreed hierarchy.",
+                        "type": "string",
+                        "constraints": {
+                            "required": True
+                        }
+                    }, {
+                      "name": "area_name",
+                      "title": "Area Name",
+                      "description": "Area name for area_id (optional).",
+                      "type": "string"
+                    }
+                ]
+            }
+        )
+        mock_datastore_search = mocker.Mock(
+            return_value={
+                'fields': [
+                    {'id': '_id', 'type': 'numeric'},
+                    {'id': 'area_id', 'type': 'numeric'},
+                    {'id': 'area_name', 'type': 'text'},
+                ]
+            }
+        )
+        mock_action = mocker.Mock()
+
+        def side_effect(action_name):
+
+            if action_name == 'datastore_search':
+                return mock_datastore_search
+
+            else:
+                return mock_action
+
+        mock_get_action = mocker.patch(
+            'ckanext.unaids.logic.toolkit.get_action',
+            side_effect=side_effect
+        )
+
+        logic.auto_populate_data_dictionary(context, resource, dataset)
+        mock_load_json_schema.assert_called_once_with(u'test_schema')
+        mock_get_action.assert_called_with('datastore_create')
+        mock_action.assert_called_with(context, {
+            u'resource_id': resource[u'id'],
+            u'force': True,
+            u'fields': [
+                {
+                    u'id': u'area_id',
+                    u'type': u'numeric',
+                    u'info': {
+                        u'label': u'Area ID',
+                        u'notes': u'An area_id from the agreed hierarchy.'
+                    }
+                }, {
+                    u'id': u'area_name',
+                    u'type': u'text',
+                    u'info': {
+                        u'label': u'Area Name',
+                        u'notes': u'Area name for area_id (optional).'
+                    }
+                }
+            ]
+        })

--- a/ckanext/unaids/tests/test_logic.py
+++ b/ckanext/unaids/tests/test_logic.py
@@ -74,7 +74,8 @@ class TestAutoPopulateDataDictionaries():
             'ckanext.unaids.logic.validation_load_json_schema',
             return_value=None
         )
-        logic.auto_populate_data_dictionary(context, resource)
+        with pytest.raises(toolkit.ValidationError):
+            logic.populate_data_dictionary_from_schema(context, resource)
         mock_load_json_schema.assert_not_called()
 
     def test_missing_schema(self, mocker):
@@ -89,7 +90,7 @@ class TestAutoPopulateDataDictionaries():
             return_value=None
         )
         with pytest.raises(toolkit.ObjectNotFound):
-            logic.auto_populate_data_dictionary(context, resource)
+            logic.populate_data_dictionary_from_schema(context, resource)
         mock_load_json_schema.assert_called_once_with(u'test_schema')
 
     def test_simple_schema(self, mocker):
@@ -145,7 +146,7 @@ class TestAutoPopulateDataDictionaries():
             side_effect=side_effect
         )
 
-        logic.auto_populate_data_dictionary(context, resource)
+        logic.populate_data_dictionary_from_schema(context, resource)
         mock_load_json_schema.assert_called_once_with(u'test_schema')
         mock_get_action.assert_called_with('datastore_create')
         mock_action.assert_called_with(context, {

--- a/ckanext/unaids/tests/test_logic.py
+++ b/ckanext/unaids/tests/test_logic.py
@@ -4,7 +4,6 @@ from ckan.plugins import toolkit
 from ckan.tests import factories
 from ckanext.unaids import logic
 from ckan.tests import factories
-import ckan.logic
 
 
 @pytest.mark.ckan_config('ckan.plugins', 'unaids authz_service blob_storage')

--- a/ckanext/unaids/tests/test_logic.py
+++ b/ckanext/unaids/tests/test_logic.py
@@ -73,7 +73,8 @@ class TestAutoPopulateDataDictionaries():
         dataset = factories.Dataset()
         resource = factories.Resource(package_id=dataset['id'])
         mock_load_json_schema = mocker.patch(
-            'ckanext.unaids.logic.validation_load_json_schema'
+            'ckanext.unaids.logic.validation_load_json_schema',
+            return_value=None
         )
         logic.auto_populate_data_dictionary(context, resource)
         mock_load_json_schema.assert_not_called()
@@ -89,71 +90,9 @@ class TestAutoPopulateDataDictionaries():
             'ckanext.unaids.logic.validation_load_json_schema',
             return_value=None
         )
-        logic.auto_populate_data_dictionary(context, resource)
+        with pytest.raises(toolkit.ObjectNotFound):
+            logic.auto_populate_data_dictionary(context, resource)
         mock_load_json_schema.assert_called_once_with(u'test_schema')
-
-    def test_schema_missing_fields(self, mocker):
-        context = {}
-        dataset = factories.Dataset()
-        resource = factories.Resource(
-            package_id=dataset['id'],
-            schema='test_schema'
-        )
-        mock_load_json_schema = mocker.patch(
-            'ckanext.unaids.logic.validation_load_json_schema',
-            return_value={'title': 'Schema without fields'}
-        )
-        logic.auto_populate_data_dictionary(context, resource)
-        mock_load_json_schema.assert_called_once_with(u'test_schema')
-
-    def test_no_datastore_upload(self, mocker):
-        context = {}
-        dataset = factories.Dataset()
-        resource = factories.Resource(
-            package_id=dataset['id'],
-            schema='test_schema'
-        )
-        mock_load_json_schema = mocker.patch(
-            'ckanext.unaids.logic.validation_load_json_schema',
-            return_value={
-                "title": "UNAIDS ART Programme Input",
-                "fields": [
-                    {
-                        "name": "area_id",
-                        "title": "Area ID",
-                        "description": "An area_id from the agreed hierarchy.",
-                        "type": "string",
-                        "constraints": {
-                            "required": True
-                        }
-                    }, {
-                        "name": "area_name",
-                        "title": "Area Name",
-                        "description": "Area name for area_id (optional).",
-                        "type": "string"
-                    }
-                ]
-            }
-        )
-        mock_datastore_search = mocker.Mock(
-            side_effect=toolkit.ObjectNotFound
-        )
-        mock_action = mocker.Mock()
-
-        def side_effect(action_name):
-
-            if action_name == 'datastore_search':
-                return mock_datastore_search
-
-            else:
-                return mock_action
-
-        mock_get_action = mocker.patch(
-            'ckanext.unaids.logic.toolkit.get_action',
-            side_effect=side_effect
-        )
-        # Check that no error is raised when resource is missing from datastore
-        logic.auto_populate_data_dictionary(context, resource)
 
     def test_simple_schema(self, mocker):
         context = {}

--- a/ckanext/unaids/tests/test_logic.py
+++ b/ckanext/unaids/tests/test_logic.py
@@ -127,10 +127,10 @@ class TestAutoPopulateDataDictionaries():
                             "required": True
                         }
                     }, {
-                      "name": "area_name",
-                      "title": "Area Name",
-                      "description": "Area name for area_id (optional).",
-                      "type": "string"
+                        "name": "area_name",
+                        "title": "Area Name",
+                        "description": "Area name for area_id (optional).",
+                        "type": "string"
                     }
                 ]
             }

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 pytest-ckan
 pytest-cov
+pytest-mock
 ckantoolkit


### PR DESCRIPTION
This PR introduces auto-population of data dictionaries from Frictionless Data table schemas used in data validation.

Current logic is to update the field's 'label' and 'description' in the data dictionary only if a corresponding field exists in the validation table schema and if no pre-existing label or description exists in the data dictionary for the field.

The logic fails silently if you try to auto-populate the data dictionary for a resource that has no associated table schema.  It will throw errors for all other failure cases.  In the "after_upload" hook we want complete silent failure though, since the task runs as a background. I have therefore decided to catch all exceptions and log them, but not block code execution, as this causes significant problems down stream. 

For convenience an action has been included to run the logic.  This will be especially useful in the migration script. 

To do:

- Test in development
- Run migration script for existing resources tested in development
- Deploy to production
