### PR TITLE
ADX-697-add-popup-modal-to-dataset-releases-actions

### DIFF
--- a/ckanext/unaids/assets/DatasetReleaseComponent.css
+++ b/ckanext/unaids/assets/DatasetReleaseComponent.css
@@ -1,0 +1,3 @@
+.dataset-release-modal .modal-dialog{
+    max-width: 400px;
+}

--- a/ckanext/unaids/assets/webassets.yml
+++ b/ckanext/unaids/assets/webassets.yml
@@ -31,3 +31,14 @@ BulkFileUploaderComponentScripts:
         - frictionless-js.js
         - build/BulkFileUploaderComponent.js
     output: unaids/%(version)s_BulkFileUploaderComponent.js
+
+DatasetReleaseComponentStyles:
+    contents:
+        - DatasetReleaseComponent.css
+    output: unaids/%(version)s_DatasetReleaseComponent.css
+
+DatasetReleaseComponentScripts:
+    contents:
+        - frictionless-js.js
+        - build/DatasetReleaseComponent.js
+    output: unaids/%(version)s_DatasetReleaseComponent.js

--- a/ckanext/unaids/blueprints/unaids_dataset_releases.py
+++ b/ckanext/unaids/blueprints/unaids_dataset_releases.py
@@ -42,6 +42,20 @@ def list_releases(dataset_type, dataset_id):
     releases = toolkit.get_action('dataset_version_list')(
         _get_context(), {'dataset_id': dataset_id}
     )
+    for release in releases:
+        release.update({
+            'url': h.url_for(
+                'dataset.read',
+                id=dataset['name'],
+                activity_id=release['activity_id']
+            ),
+            'creator_name_as_raw_html': \
+                h.linked_user(release['creator_user_id'], 0, 0),
+            'created_datetime_ago_string': \
+                h.time_ago_from_timestamp(release['created']),
+            'created_datetime_string': \
+                h.render_datetime(release['created'], with_hours=True)
+        })
     return toolkit.render(
         'package/releases/list.html',
         {

--- a/ckanext/unaids/react/components/DatasetReleaseComponent/index.js
+++ b/ckanext/unaids/react/components/DatasetReleaseComponent/index.js
@@ -1,0 +1,30 @@
+import ReactDOM from 'react-dom';
+import React from 'react';
+import App from './src/App';
+
+const componentElement =
+  document.getElementById('DatasetReleaseComponent');
+const getAttr = key => {
+  const val = componentElement.getAttribute(`data-${key}`);
+  return ['None', ''].includes(val) ? null : val;
+};
+
+const datasetReleases = JSON.parse(getAttr('datasetReleases'));
+
+const loadCkan = callback => {
+  if (
+    typeof ckan === 'undefined' ||
+    typeof ckan.i18n === 'undefined' ||
+    typeof ckan.i18n._ === 'undefined') {
+    setTimeout(() => loadCkan(callback), 10);
+  } else {
+    callback();
+  }
+};
+
+loadCkan(() => {
+  ReactDOM.render(
+    <App {...{ datasetReleases }} />,
+    componentElement
+  );
+});

--- a/ckanext/unaids/react/components/DatasetReleaseComponent/src/App.js
+++ b/ckanext/unaids/react/components/DatasetReleaseComponent/src/App.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import Modal from './Modal';
+
+export default function App({ datasetReleases }) {
+
+    const actions = [
+        {
+            type: 'restore',
+            title: ckan.i18n._('Make release the latest version'),
+            icon: 'fa-refresh',
+        },
+        {
+            type: 'edit',
+            title: ckan.i18n._('Edit Release'),
+            icon: 'fa-pencil'
+        },
+        {
+            type: 'delete',
+            title: ckan.i18n._('Delete Release'),
+            icon: 'fa-trash'
+        }
+    ];
+
+    return (
+        <>
+            <table>
+                <thead>
+                    <tr>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {datasetReleases.map(release => (
+                        <tr>
+                            <td>
+                                <div className="row vertical-align">
+                                    <div className="col-xs-12 col-md-6">
+                                        <div className="release-title"><h4><i className="fa fa-tag text-muted fa-fw"></i><a href={release.url}>{release.name}</a></h4></div>
+                                        {release.notes &&
+                                            <div className="text-muted release-notes">{release.notes}</div>
+                                        }
+                                        <div className="release-creator">
+                                            {ckan.i18n._('Created by')}
+                                            <span> </span>
+                                            <span dangerouslySetInnerHTML={{
+                                                __html: release.creator_name_as_raw_html
+                                            }} />
+                                        </div>
+                                    </div>
+                                    <div className="col-md-3">
+                                        <div className="release-date">
+                                            <span title={release.created_datetime_string}>{release.created_datetime_ago_string}</span>
+                                        </div>
+                                    </div>
+                                    <div className="col-xs-12 col-md-3">
+                                        <div className="release-actions">
+                                            <div className="btn-group btn-group-xs">
+                                                {actions.map(action =>
+                                                    <button
+                                                        type="button"
+                                                        className="btn btn-default"
+                                                        data-toggle="modal"
+                                                        data-target={`#${action.type}_release_${release.id}`}
+                                                        title={action.title}
+                                                    ><i className={`fa ${action.icon}`}></i></button>
+                                                )}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table >
+            {datasetReleases.map(release =>
+                actions.map(action => <Modal {...{ release, action }} />)
+            )}
+        </>
+    )
+
+}

--- a/ckanext/unaids/react/components/DatasetReleaseComponent/src/Modal.js
+++ b/ckanext/unaids/react/components/DatasetReleaseComponent/src/Modal.js
@@ -1,0 +1,94 @@
+import React from 'react';
+
+export default function Modal({ release, action }) {
+
+    function RestoreOrDeleteReleaseContainer(modalText) {
+        return (
+            <>
+                <div>{modalText}</div>
+                <br />
+                <div id="RestoreOrDeleteReleaseContainer" className="thumbnail alert-info">
+                    <div className="row">
+                        <div className="col-md-3 text-right">
+                            <i className="fa fa-code-fork fa-3x"></i>
+                        </div>
+                        <div className="col-md-9">
+                            <h3>{release.name}</h3>
+                            <div>Description: {release.notes || ckan.i18n._('Not Set')}</div>
+                        </div>
+                    </div>
+                </div>
+            </>
+        )
+    };
+
+    function EditReleaseContainer() {
+        return (
+            <>
+                <div>
+                    <label className="control-label" for="name">
+                        <span title="This field is required" className="control-required">*</span>
+                        <span> Name</span>
+                    </label>
+                    <input
+                        type="text"
+                        id="name"
+                        className="form-control"
+                        placeholder={ckan.i18n._('Version 1.1')}
+                        required
+                    />
+                </div>
+                <br />
+                <div>
+                    <label className="control-label" for="notes">Description</label>
+                    <textarea
+                        id="notes"
+                        className="form-control"
+                        placeholder={ckan.i18n._('Description')}
+                        rows="3"
+                    >
+                        {release.notes && release.notes}
+                    </textarea>
+                </div>
+            </>
+        )
+    };
+
+    function ModalBody() {
+        if (action.type === 'restore') {
+            return RestoreOrDeleteReleaseContainer(
+                ckan.i18n._('Are you sure you want to restore the following release?')
+            );
+        } else if (action.type === 'edit') {
+            return EditReleaseContainer();
+        } else if (action.type === 'delete') {
+            return RestoreOrDeleteReleaseContainer(
+                ckan.i18n._('Are you sure you want to delete the following release?')
+            );
+        } else {
+            throw `Unhandled action.type: ${action.type}`;
+        }
+    };
+
+    return (
+        <>
+            <div className="modal fade dataset-release-modal" id={`${action.type}_release_${release.id}`} tabindex="-1" role="dialog">
+                <div className="modal-dialog" role="document">
+                    <form className="modal-content">
+                        <div className="modal-header">
+                            <button type="button" className="close" data-dismiss="modal"><span>&times;</span></button>
+                            <h4 className="modal-title">{action.title}</h4>
+                        </div>
+                        <div className="modal-body">
+                            <ModalBody />
+                        </div>
+                        <div className="modal-footer">
+                            <button type="button" className="btn btn-default" data-dismiss="modal">Close</button>
+                            <button type="button" className="btn btn-primary">Save changes</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </>
+    )
+}

--- a/ckanext/unaids/react/webpack.config.js
+++ b/ckanext/unaids/react/webpack.config.js
@@ -5,7 +5,9 @@ const components = {
     'FileInputComponent':
         path.resolve(__dirname, 'components', 'FileInputComponent/index.js'),
     'BulkFileUploaderComponent':
-        path.resolve(__dirname, 'components', 'BulkFileUploaderComponent/index.js')
+        path.resolve(__dirname, 'components', 'BulkFileUploaderComponent/index.js'),
+    'DatasetReleaseComponent':
+        path.resolve(__dirname, 'components', 'DatasetReleaseComponent/index.js'),
 }
 
 module.exports = {

--- a/ckanext/unaids/theme/templates/package/releases/list.html
+++ b/ckanext/unaids/theme/templates/package/releases/list.html
@@ -52,6 +52,7 @@
         </li>
     </ul>
     <div id="ReleasesTableContainer">
+        <h3>Old implementation</h3>
         <table>
             <thead>
                 <tr>
@@ -100,6 +101,15 @@
                 {% endfor %}
             </tbody>
         </table>
+        <br /><br />
+        <h3>New implementation</h3>
+        {% asset 'ckanext-unaids/DatasetReleaseComponentStyles' %}
+            <div
+            id="DatasetReleaseComponent"
+            data-datasetReleases="{{ dataset_releases|json_dumps|replace('"', '\"') }}"
+        ></div>
+        {% asset 'ckanext-unaids/DatasetReleaseComponentScripts' %}
+
     </div>
     <script>
         window.onload = function() {


### PR DESCRIPTION
- https://fjelltopp.atlassian.net/browse/ADX-697

# Status
- This PR is incomplete
- So far the releases list view has been converted into react
- When clicking the restore/edit/delete buttons a popup modal opens
- The `<form>` elements on the popup modal are incomplete

![image](https://user-images.githubusercontent.com/2634482/156555237-339f4b35-dd4d-4b94-a95c-d27b90321a90.png)
