### PR TITLE
ADX-622-fix-file-uploads-being-lowercase

### DIFF
--- a/ckanext/unaids/actions.py
+++ b/ckanext/unaids/actions.py
@@ -206,3 +206,13 @@ def user_show_me(context, resource_dict):
         return auth_user_obj.as_dict()
     else:
         raise NotAuthorized
+
+
+@t.chained_action
+@t.side_effect_free
+def resource_search(original_action, context, data_dict):
+    response = original_action(context, data_dict)
+    print('~'*50)
+    print(response)
+    print('~'*50)
+    return response

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -102,7 +102,8 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
             u'package_show': actions.dataset_version_show,
             u'package_activity_list': actions.package_activity_list,
             u'format_guess': actions.format_guess,
-            u'user_show_me': actions.user_show_me
+            u'user_show_me': actions.user_show_me,
+            u'resource_search': actions.resource_search,
         }
 
     def dataset_facets(self, facet_dict, package_type):


### PR DESCRIPTION
- https://fjelltopp.atlassian.net/browse/ADX-622

Proposed solution:
- I want to modify `munge_filename` in `ckan/ckan/lib/munge.py`
- Which is used by `resource_dictize` in `ckan/ckan/lib/dictization/model_dictize.py`
- Which is called by `resource_list_dictize` in `ckan/ckan/lib/dictization/model_dictize.py`
- Which is called by `resource_search` in `ckan/ckan/logic/action/get.py`
- So we want to override the `resource_search` from `ckanext-unaids` and modify the returned object
- We should hopefully be able to change the file_name by modifying the object

Problem: The following PR shows an attempt to override `resource_search` but it doesn't seem to be working