### PR TITLE
ADX-803-add-datasetid-to-navigator-url

### DIFF
--- a/ckanext/unaids/helpers.py
+++ b/ckanext/unaids/helpers.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 from ckan.lib.helpers import url_for_static_or_external, check_access
-from ckan.plugins.toolkit import get_action
+from ckan.plugins.toolkit import get_action, request
 from ckan.plugins import toolkit as toolkit
 from ckan.common import _, g
 import logging
@@ -127,3 +127,7 @@ def get_current_dataset_release(dataset_id, activity_id=None):
     for release in releases:
         if release['activity_id'] == activity_id:
             return release
+
+
+def get_navigator_locale():
+    return request.environ['CKAN_LANG'].split('_')[0]

--- a/ckanext/unaids/helpers.py
+++ b/ckanext/unaids/helpers.py
@@ -129,5 +129,5 @@ def get_current_dataset_release(dataset_id, activity_id=None):
             return release
 
 
-def get_navigator_locale():
+def get_language_code():
     return request.environ['CKAN_LANG'].split('_')[0]

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -25,7 +25,7 @@ from ckanext.unaids.helpers import (
     get_all_organizations,
     get_bulk_file_uploader_default_fields,
     get_current_dataset_release,
-    get_navigator_locale
+    get_language_code
 )
 import ckanext.blob_storage.helpers as blobstorage_helpers
 import ckanext.unaids.actions as actions
@@ -131,7 +131,7 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
             u'max_resource_size': uploader.get_max_resource_size,
             u'bulk_file_uploader_default_fields': get_bulk_file_uploader_default_fields,
             u'get_current_dataset_release': get_current_dataset_release,
-            u'get_navigator_locale': get_navigator_locale
+            u'get_language_code': get_language_code
         }
 
     # IAuthFunctions

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -24,7 +24,8 @@ from ckanext.unaids.helpers import (
     get_user_obj,
     get_all_organizations,
     get_bulk_file_uploader_default_fields,
-    get_current_dataset_release
+    get_current_dataset_release,
+    get_navigator_locale
 )
 import ckanext.blob_storage.helpers as blobstorage_helpers
 import ckanext.unaids.actions as actions
@@ -130,6 +131,7 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
             u'max_resource_size': uploader.get_max_resource_size,
             u'bulk_file_uploader_default_fields': get_bulk_file_uploader_default_fields,
             u'get_current_dataset_release': get_current_dataset_release,
+            u'get_navigator_locale': get_navigator_locale
         }
 
     # IAuthFunctions

--- a/ckanext/unaids/theme/templates/package/read_base.html
+++ b/ckanext/unaids/theme/templates/package/read_base.html
@@ -3,7 +3,7 @@
 {% block content_action %}
   {% if not is_activity_archive %}
     {% if h.check_access('package_update', {'id':pkg.id }) %}
-      <a class="btn btn-default" href="https://navigator.unaids.org/{{ h.get_navigator_locale() }}/?datasetId={{ pkg.id }}" target="_blank">
+      <a class="btn btn-default" href="https://navigator.unaids.org/{{ h.get_language_code() }}/?datasetId={{ pkg.id }}" target="_blank">
         <i class="fa fa-compass"></i>
         {{_('Navigator')}}
       </a>

--- a/ckanext/unaids/theme/templates/package/read_base.html
+++ b/ckanext/unaids/theme/templates/package/read_base.html
@@ -3,10 +3,11 @@
 {% block content_action %}
   {% if not is_activity_archive %}
     {% if h.check_access('package_update', {'id':pkg.id }) %}
-        <a class="btn btn-default" href="https://navigator.unaids.org/?datasetId={{ pkg.id }}" target="_blank">
-          <i class="fa fa-compass"></i>
-          {{_('Navigator')}}
-        </a>
+      {% set navigator_locale = request.environ.CKAN_LANG.split('_')[0] %}
+      <a class="btn btn-default" href="https://navigator.unaids.org/{{ navigator_locale }}/?datasetId={{ pkg.id }}" target="_blank">
+        <i class="fa fa-compass"></i>
+        {{_('Navigator')}}
+      </a>
       {% link_for _('Manage'), named_route=pkg.type ~ '.edit', id=pkg.name, class_='btn btn-default', icon='wrench' %}
     {% endif %}
   {% endif %}

--- a/ckanext/unaids/theme/templates/package/read_base.html
+++ b/ckanext/unaids/theme/templates/package/read_base.html
@@ -3,7 +3,7 @@
 {% block content_action %}
   {% if not is_activity_archive %}
     {% if h.check_access('package_update', {'id':pkg.id }) %}
-        <a class="btn btn-default" href="https://navigator.unaids.org" target="_blank">
+        <a class="btn btn-default" href="https://navigator.unaids.org/?datasetId={{ pkg.id }}" target="_blank">
           <i class="fa fa-compass"></i>
           {{_('Navigator')}}
         </a>

--- a/ckanext/unaids/theme/templates/package/read_base.html
+++ b/ckanext/unaids/theme/templates/package/read_base.html
@@ -3,8 +3,7 @@
 {% block content_action %}
   {% if not is_activity_archive %}
     {% if h.check_access('package_update', {'id':pkg.id }) %}
-      {% set navigator_locale = request.environ.CKAN_LANG.split('_')[0] %}
-      <a class="btn btn-default" href="https://navigator.unaids.org/{{ navigator_locale }}/?datasetId={{ pkg.id }}" target="_blank">
+      <a class="btn btn-default" href="https://navigator.unaids.org/{{ h.get_navigator_locale() }}/?datasetId={{ pkg.id }}" target="_blank">
         <i class="fa fa-compass"></i>
         {{_('Navigator')}}
       </a>


### PR DESCRIPTION
- [ADX-803-add-datasetid-to-navigator-url](https://fjelltopp.atlassian.net/browse/ADX-803)
- Update the link on the dataset_view page to include the dataset_id in the url so that users are redirected directly to the correct workflow within navigator

![image](https://user-images.githubusercontent.com/2634482/157023996-a67b936d-b521-439f-8ee1-7f25ec36bf87.png)
