### PR TITLE
ADX-622 case sensitive download links

### DIFF
--- a/ckanext/unaids/logic.py
+++ b/ckanext/unaids/logic.py
@@ -1,3 +1,4 @@
+from ckan import model
 from ckan.plugins import toolkit
 
 
@@ -25,3 +26,12 @@ def validate_resource_upload_fields(context, resource_dict):
             toolkit.get_validator('valid_lfs_prefix')(lfs_prefix)
         except toolkit.Invalid as err:
             raise toolkit.ValidationError([err.error])
+
+
+def update_filename_in_resource_url(resource):
+    filename = str(model.Resource.get(resource['id']).url)
+    url_segments = resource['url'].split('/')
+    if filename and len(url_segments):
+        new_url_segments = url_segments[:-1] + [filename]
+        resource['url'] = '/'.join(new_url_segments)
+    return resource

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -12,6 +12,7 @@ from ckan.lib.plugins import DefaultTranslation
 from ckan.logic import get_action
 from werkzeug.datastructures import FileStorage as FlaskFileStorage
 
+from ckanext.blob_storage.interfaces import IResourceDownloadHandler
 from ckanext.unaids.dataset_transfer.model import tables_exists
 from ckanext.unaids.validators import (
     if_empty_guess_format,
@@ -73,6 +74,7 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
     p.implements(p.IValidators)
     p.implements(p.IActions)
     p.implements(IDataValidation)
+    p.implements(IResourceDownloadHandler, inherit=True)
 
     # IClick
     def get_commands(self):
@@ -186,6 +188,10 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
             _update_resource_last_modified_date(resource, current=current)
             logic.validate_resource_upload_fields(context, resource)
         return resource
+
+    def before_show(self, resource):
+        if _data_dict_is_resource(resource):
+            return logic.update_filename_in_resource_url(resource)
 
 
 class UNAIDSReclineView(ReclineViewBase):

--- a/ckanext/unaids/tests/test_logic.py
+++ b/ckanext/unaids/tests/test_logic.py
@@ -1,5 +1,7 @@
 import pytest
+
 from ckan.plugins import toolkit
+from ckan.tests import factories
 from ckanext.unaids import logic
 
 
@@ -47,3 +49,16 @@ def test_validate_resource_upload_fields(lfs_prefix, sha256, size, valid):
             logic.validate_resource_upload_fields(context, resource_dict)
     else:
         logic.validate_resource_upload_fields(context, resource_dict)
+
+
+@pytest.mark.ckan_config('ckan.plugins', 'unaids authz_service blob_storage')
+@pytest.mark.usefixtures('with_plugins')
+def test_update_filename_in_resource_url():
+    actual_filename = "TeSt.CSV"
+    resource = factories.Resource(url_type="upload",
+                                  url=actual_filename,
+                                  sha256="cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919",
+                                  lfs_prefix="lfs/prefix",
+                                  size=500
+                                  )
+    assert resource['url'].endswith(actual_filename)


### PR DESCRIPTION
1. We have a custom uploader which preserves original uploaded filenames as `url` column in resource db
2. the resource_dictize core ckan function is using ckan.lib.munge_filename to generate full urls for resources is solr visible with `resource_show`

I think the easiest fix for this is to leverage `IResourceController` and with `before_show` I can substitute the filename in resource_dict url with the value resource.url we store in the db.
The filename is still stripped from whitespaces and special characters by giftless but we're getting:
`CKAN Datasets & Resources.postman_collection` -> `CKANDatasetsResources.postman_collection.json`
which is quite alright in my opinion.