### PR TITLE
ADX-811-fix-broken-resource-sprites

### DIFF
--- a/ckanext/unaids/assets/custom.css
+++ b/ckanext/unaids/assets/custom.css
@@ -156,7 +156,7 @@ aside.secondary{
   background-color: white;
 }
 .format-label{
-    background: url("sprite-resource-icons.png") no-repeat 0 0;
+    background: url("/sprite-resource-icons.png") no-repeat 0 0;
     width: 32px;
     height: 35px;
     background-position: 0px -62px;


### PR DESCRIPTION
- https://fjelltopp.atlassian.net/browse/ADX-811
- All css references with `url(` have also been manually checked in `custom.css` and `unaids.css`
- Only `sprite-resource-icons.png` was broken

![image](https://user-images.githubusercontent.com/2634482/161725623-fa293289-c205-4af5-8575-8555bba85123.png)
