### PR TITLE
ADX-813-remove-deprecated-center-tags

### DIFF
--- a/ckanext/unaids/theme/templates/home/layout1.html
+++ b/ckanext/unaids/theme/templates/home/layout1.html
@@ -111,26 +111,20 @@
 <div class="homepage-partners">
   <div class="container">
     <div class="row">
-      <div class="col-xs-12">
-        <center>
-          <H2> {{_('The AIDS Data Repository is a project by')}} </H2>
-        </center>
+      <div class="col-xs-12 text-center">
+        <H2> {{_('The AIDS Data Repository is a project by')}} </H2>
       </div>
     </div>
     <div class="row">
-      <div class="col-xs-12">
-        <center>
-          <a class="unaids-logo" href="https://www.unaids.org"  target="_blank">
+      <div class="col-xs-12 text-center">
+        <a class="unaids-logo" href="https://www.unaids.org"  target="_blank">
             <img class="img-responsive" src="{{ h.url_for_static('/unaids.png') }}" alt="aim" width="80%" />
           </a>
-        </center>
       </div>
     </div>
     <div class="row">
-      <div class="col-xs-12">
-        <center>
-          <H2> {{_('With support from')}} </H2>
-        </center>
+      <div class="col-xs-12 text-center">
+        <H2> {{_('With support from')}} </H2>
       </div>
     </div>
     <div class="row">

--- a/ckanext/unaids/theme/templates/home/layout1.html
+++ b/ckanext/unaids/theme/templates/home/layout1.html
@@ -118,7 +118,7 @@
     <div class="row">
       <div class="col-xs-12 text-center">
         <a class="unaids-logo" href="https://www.unaids.org"  target="_blank">
-            <img class="img-responsive" src="{{ h.url_for_static('/unaids.png') }}" alt="aim" width="80%" />
+            <img src="{{ h.url_for_static('/unaids.png') }}" alt="aim" width="80%" />
           </a>
       </div>
     </div>
@@ -128,24 +128,24 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-md-4">
+      <div class="col-xs-4">
         <div class="text-center">
           <a class="" href="https://www.avenirhealth.org/"  target="_blank">
-            <img class="img-responsive avenir-logo" src="{{ h.url_for_static('/avenir.png') }}" alt="aim" width="80%" />
+            <img class="avenir-logo" src="{{ h.url_for_static('/avenir.png') }}" alt="aim" width="80%" />
           </a>
         </div>
       </div>
-      <div class="col-md-4">
+      <div class="col-xs-4">
         <div class="text-center">
           <a class="" href="http://www.fjelltopp.org"  target="_blank">
-            <img class="img-responsive fjelltopp-logo" src="{{ h.url_for_static('/fjelltopp.png') }}" alt="aim" width="80%" />
+            <img class="fjelltopp-logo" src="{{ h.url_for_static('/fjelltopp.png') }}" alt="aim" width="80%" />
           </a>
         </div>
       </div>
-      <div class="col-md-4">
+      <div class="col-xs-4">
         <div class="text-center" style="margin-top: 10px;">
           <a class="" href="https://www.imperial.ac.uk/"  target="_blank">
-            <img class="img-responsive imperial-logo" src="{{ h.url_for_static('/imperial.png') }}" alt="aim" width="80%" />
+            <img class="imperial-logo" src="{{ h.url_for_static('/imperial.png') }}" alt="aim" width="80%" />
           </a>
         </div>
       </div>


### PR DESCRIPTION
- https://fjelltopp.atlassian.net/browse/ADX-813
- Made change as [html5 does not support `<center>` tags anymore](https://www.w3docs.com/learn-html/html-center-tag.html)
- Swapped out `<center>hello</center>` with `<div class="text-center">hello</div>`
- Also fixed bad use of `img-responsive` and bootstrap column sizing