### PR TITLE
ADX-815 Load CSS styles at the top of the page, not the bottom

### DIFF
--- a/ckanext/unaids/theme/templates/base.html
+++ b/ckanext/unaids/theme/templates/base.html
@@ -1,6 +1,6 @@
 {% ckan_extends %}
 
-{% block custom_styles %}
+{% block styles %}
   {{ super() }}
   {% asset 'ckanext-unaids/UnaidsCSS' %}
 {% endblock %}


### PR DESCRIPTION
The CSS was being loaded in the wrong place.  This was creating a flash of unformated website whilst the browser loaded stuff before the CSS files. This tiny PR just ensures the CSS is loaded in the head tag. 