### PR TITLE
ADX-817 non-ascii filenames

### DIFF
--- a/ckanext/unaids/logic.py
+++ b/ckanext/unaids/logic.py
@@ -1,4 +1,5 @@
 from ckan import model
+from ckan.lib.munge import substitute_ascii_equivalents
 from ckan.plugins import toolkit
 from ckanext.validation.helpers import validation_load_json_schema
 
@@ -31,11 +32,13 @@ def validate_resource_upload_fields(context, resource_dict):
 
 def update_filename_in_resource_url(resource):
     if resource['url_type'] == 'upload':
-        filename = str(model.Resource.get(resource['id']).url)
+        filename = model.Resource.get(resource['id']).url
+        # core CKAN functionality fails for non ascii filenames
+        filename = substitute_ascii_equivalents(filename)
         url_segments = resource['url'].split('/')
         if filename and len(url_segments):
             new_url_segments = url_segments[:-1] + [filename]
-            resource['url'] = '/'.join(new_url_segments)
+            resource['url'] = u'/'.join(new_url_segments)
     return resource
 
 

--- a/ckanext/unaids/tests/test_logic.py
+++ b/ckanext/unaids/tests/test_logic.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import pytest
 
 from ckan.plugins import toolkit
@@ -54,14 +55,15 @@ def test_validate_resource_upload_fields(lfs_prefix, sha256, size, valid):
 @pytest.mark.ckan_config('ckan.plugins', 'unaids authz_service blob_storage')
 @pytest.mark.usefixtures('with_plugins')
 def test_update_filename_in_upload_resource_url():
-    actual_filename = "TeSt.CSV"
+    actual_filename = u"TeStè.CSV"
+    expected_filename = u"TeSte.CSV"
     resource = factories.Resource(url_type="upload",
                                   url=actual_filename,
                                   sha256="cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919",
                                   lfs_prefix="lfs/prefix",
                                   size=500
                                   )
-    assert resource['url'].endswith(actual_filename)
+    assert resource['url'].endswith(expected_filename)
 
 
 @pytest.mark.ckan_config('ckan.plugins', 'unaids authz_service blob_storage')


### PR DESCRIPTION
The ckanext-unaids filename generator was not handling non-ascii symbol.
I needed to get rid of non-ascii characters enterily due to CKAN not handling them even after upload (things like view controller etc. are erroring).

With the migration to python3 issues like this should get much easier.