### PR TITLE
ADX-815 Remove default CKAN css

### DIFF
--- a/ckanext/unaids/theme/templates/base.html
+++ b/ckanext/unaids/theme/templates/base.html
@@ -1,7 +1,6 @@
 {% ckan_extends %}
 
 {% block styles %}
-  {{ super() }}
   {% asset 'ckanext-unaids/UnaidsCSS' %}
 {% endblock %}
 


### PR DESCRIPTION
Replace default CKAN styling, since we are loading UNAIDS styling. 

We are using super() for the styling block, but the only style this imports from core CKAN is the CKAN default CSS.