### PR TITLE
ADX-841 bug fix

### DIFF
--- a/ckanext/unaids/blueprints/validate_user_profile.py
+++ b/ckanext/unaids/blueprints/validate_user_profile.py
@@ -44,7 +44,7 @@ def check_user_affiliation():
 
 
 validate_user_profile.add_url_rule(
-    "/",
+    "/check_user_affiliation",
     view_func=check_user_affiliation,
     methods=['GET']
 )

--- a/ckanext/unaids/tests/test_blueprints.py
+++ b/ckanext/unaids/tests/test_blueprints.py
@@ -44,7 +44,8 @@ class TestValidateUserProfileBlueprint(object):
         assert '/dashboard/' in user_response.location
 
     def test_annonymous_access_to_index_page(self, app):
-        index_response = app.get('/',
+        index_response = app.get(
+            '/',
             follow_redirects=False
         )
         assert index_response.status_code == 200

--- a/ckanext/unaids/tests/test_blueprints.py
+++ b/ckanext/unaids/tests/test_blueprints.py
@@ -42,3 +42,14 @@ class TestValidateUserProfileBlueprint(object):
             follow_redirects=False,
         )
         assert '/dashboard/' in user_response.location
+
+    def test_validate_user_profile_blueprint_does_nothing_if_not_logged_in(self, app):
+        user_response = app.get(
+            url=ckan.plugins.toolkit.url_for(
+                'home.index'
+            ),
+            follow_redirects=False,
+        )
+        assert ckan.plugins.toolkit.url_for(
+                'home.index'
+            ) in user_response.location

--- a/ckanext/unaids/tests/test_blueprints.py
+++ b/ckanext/unaids/tests/test_blueprints.py
@@ -8,7 +8,7 @@ from ckanext.unaids.tests.factories import User
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'unaids')
+@pytest.mark.ckan_config('ckan.plugins', 'unaids pages')
 @pytest.mark.usefixtures('with_plugins')
 class TestValidateUserProfileBlueprint(object):
 
@@ -43,13 +43,8 @@ class TestValidateUserProfileBlueprint(object):
         )
         assert '/dashboard/' in user_response.location
 
-    def test_validate_user_profile_blueprint_does_nothing_if_not_logged_in(self, app):
-        user_response = app.get(
-            url=ckan.plugins.toolkit.url_for(
-                'home.index'
-            ),
-            follow_redirects=False,
+    def test_annonymous_access_to_index_page(self, app):
+        index_response = app.get('/',
+            follow_redirects=False
         )
-        assert ckan.plugins.toolkit.url_for(
-                'home.index'
-            ) in user_response.location
+        assert index_response.status_code == 200


### PR DESCRIPTION
So, for future reference, I had used the following for registering my blueprint:
```python
validate_user_profile = Blueprint(
    'validate_user_profile',
    __name__,
)
```
and
```python
validate_user_profile.add_url_rule(
    "/",
    view_func=check_user_affiliation,
    methods=['GET']
)
```
I had, incorrectly, presumed that without explicitly setting `prefix=` in the Blueprint constructor call that it would default to the blueprint name... I was wrong and so my `add_url_rule` was overwriting the `home.index` url.

This PR includes a general test to make sure we don't do this again with future blueprints (thanks @tomeksabala) and the fix.

Tested manually locally and passes integration tests.