### PR TITLE
ADX-876 AUTH0 SSO PoC - enable job title and affiliation user profile fields

### DIFF
--- a/ckanext/unaids/actions.py
+++ b/ckanext/unaids/actions.py
@@ -233,32 +233,22 @@ def user_show(original_action, context, data_dict):
 
 @t.chained_action
 def user_create(original_action, context, data_dict):
-    custom_user_profile.validate_plugin_extras_provided(data_dict)
-
-    user = original_action(context, data_dict)
-    user_obj = custom_user_profile.get_user_obj(context)
-
-    plugin_extras = custom_user_profile.init_plugin_extras(user_obj.plugin_extras)
-    plugin_extras = custom_user_profile.add_to_plugin_extras(plugin_extras, data_dict)
-    user_obj.plugin_extras = plugin_extras
-
-    custom_user_profile.commit_plugin_extras(context)
-
-    user.update(plugin_extras["unaids"])
-    return user
+    return add_plugin_extras_to_user(context, data_dict, original_action)
 
 
 @t.chained_action
 def user_update(original_action, context, data_dict):
-    custom_user_profile.validate_plugin_extras_provided(data_dict)
+    return add_plugin_extras_to_user(context, data_dict, original_action)
 
+
+def add_plugin_extras_to_user(context, data_dict, original_action):
     user = original_action(context, data_dict)
     user_obj = custom_user_profile.get_user_obj(context)
 
     plugin_extras = custom_user_profile.init_plugin_extras(user_obj.plugin_extras)
     plugin_extras = custom_user_profile.add_to_plugin_extras(plugin_extras, data_dict)
-    user_obj.plugin_extras = plugin_extras
 
+    user_obj.plugin_extras = plugin_extras
     custom_user_profile.commit_plugin_extras(context)
 
     user.update(plugin_extras["unaids"])

--- a/ckanext/unaids/blueprints/validate_user_profile.py
+++ b/ckanext/unaids/blueprints/validate_user_profile.py
@@ -23,10 +23,6 @@ def check_user_affiliation():
     except Exception:
         h.redirect_to('user.login')
 
-    return h.redirect_to('dashboard.index')
-    # NOTE this redirect prevents the rest of the blueprint logic
-    # as a temporary measure due to SAML2 extension conflicts
-
     try:
         user_profile_dict = user_profile.as_dict()
         plugin_extras = user_profile_dict.get('plugin_extras', {})

--- a/ckanext/unaids/custom_user_profile.py
+++ b/ckanext/unaids/custom_user_profile.py
@@ -28,12 +28,9 @@ def commit_plugin_extras(context):
 def validate_plugin_extras_provided(data_dict):
     for field in CUSTOM_FIELDS:
         if not data_dict.get(field["name"]):
-            pass
-            # NOTE the following raise has been commented out
-            # as a temporary measure due to SAML2 extension conflicts
-            # raise t.ValidationError(
-            #     {field["name"]: ["Missing value"]}
-            # )
+            raise t.ValidationError(
+                {field["name"]: ["Missing value"]}
+            )
 
 
 def init_plugin_extras(plugin_extras):

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -218,7 +218,7 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
         user = model.Session.query(model.User).filter(model.User.id == user_dict['id']).first()
 
         for plugin_key in user.plugin_extras.keys():
-            if plugin_key not in user_dict[u'plugin_extras'].keys():
+            if plugin_key not in user_dict[u'plugin_extras'].keys() and plugin_key != u'saml2auth':
                 user_dict[u'plugin_extras'][plugin_key] = user.plugin_extras[plugin_key]
 
 


### PR DESCRIPTION
Enables the job title and affiliation fields from #235 (temporarily disabled in #239).

Specifically, the catches for identifying profiles without these fields are rewritten to be compatible with ckanext-saml2auth and our Auth0 SSO PoC.