### PR TITLE
ADX-879 Select & mark resource if search query matches their id

### DIFF
--- a/ckanext/unaids/react/components/FileInputComponent/src/ResourceForker.js
+++ b/ckanext/unaids/react/components/FileInputComponent/src/ResourceForker.js
@@ -97,7 +97,7 @@ const DatasetGroup = ({ dataset, setResourceAndMetadata, searchQuery, currentRes
                 .toLowerCase()
                 .split(' ')
                 .filter((word) => word.length > 0)
-                .map((word) => resource.name.toLowerCase().includes(word))
+                .map((word) => (resource.name + resource.id).toLowerCase().includes(word))
                 .some((x) => x === true)
         );
 
@@ -179,7 +179,7 @@ const ResourceButton = ({ resource, dataset, setResourceAndMetadata, searchQuery
                         Modified {resource.last_modified}
                         &ensp;|&ensp;
                     </strong>
-                    {resource.id}
+                    {markQuerySubstring(resource.id, searchQuery)}
                 </p>
             </div>
             <div className="dropdown btn-group">


### PR DESCRIPTION
Depends upon https://github.com/fjelltopp/ckanext-fork/pull/12 being merged.

Some small changes to ensure the JS ResourceForker responds to these changes in resource_autocomplete endpoint. 

![image](https://user-images.githubusercontent.com/8988344/203320920-227f3d98-ce50-4083-a239-9e9fdbce7496.png)
