### PR TITLE
ADX-891 Improve markQuerySubstring and add error boundary

### DIFF
--- a/ckanext/unaids/assets/FileInputComponent.css
+++ b/ckanext/unaids/assets/FileInputComponent.css
@@ -17,7 +17,8 @@
     margin-bottom: 30px;
 }
 
-.resource-fork-component {
+.resource-fork-component,
+.file-input-error-component {
     text-align: left;
     padding: 15px;
     border-width: 3px;
@@ -27,6 +28,17 @@
     background-color: #fafafa;
     margin-bottom: 20px;
     position: relative;
+}
+
+/* ERROR COMPONENT */
+.file-input-error-component {
+    vertical-align: middle;
+}
+
+.file-input-error-component .error {
+    color:#e31837;
+    float: left;
+    font-size: x-large;
 }
 
 /* FORK RESOURCE SEARCH BAR */

--- a/ckanext/unaids/react/components/FileInputComponent/src/App.js
+++ b/ckanext/unaids/react/components/FileInputComponent/src/App.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import axios from 'axios';
 import ProgressBar from './ProgressBar';
 import DisplayUploadedFile from './DisplayUploadedFile';
@@ -29,6 +30,29 @@ const getRootResourceActivityDetails = async (resourceID, activityID) => {
         }
     }
     return [resourceData, datasetData];
+};
+
+const ErrorComponent = ({ error, resetErrorBoundary }) => {
+    return (
+        <div className="file-input-error-component">
+            <div className="alert alert-danger">
+                <p>
+                    <i className="fa fa-exclamation-triangle"></i> {error.error || 'Unfortunately an error has occured.'}
+                </p>
+                <p>
+                    {error.description && <span>{error.description}</span>}
+                    <br />
+                    <span>
+                        Please click{' '}
+                        <a href="#" onClick={resetErrorBoundary}>
+                            here
+                        </a>{' '}
+                        to try again.
+                    </span>
+                </p>
+            </div>
+        </div>
+    );
 };
 
 export default function App({
@@ -156,16 +180,14 @@ export default function App({
 
     if (uploadError)
         return (
-            <div className="alert alert-danger">
-                <p>
-                    <i className="fa fa-exclamation-triangle"></i> {uploadError.error}
-                </p>
-                <p>
-                    <span>{uploadError.description}</span>
-                    <br />
-                    <span>{ckan.i18n._('Please refresh this page and try again.')}</span>
-                </p>
-            </div>
+            <ErrorComponent
+                error={uploadError}
+                resetErrorBoundary={() => {
+                    setHiddenInputs(null, {});
+                    setUploadProgress(defaultUploadProgress);
+                    setUploadError(false);
+                }}
+            />
         );
 
     function UploaderComponent() {
@@ -226,9 +248,15 @@ export default function App({
         }
     }
     return (
-        <>
+        <ErrorBoundary
+            FallbackComponent={ErrorComponent}
+            onReset={() => {
+                setHiddenInputs(null, {});
+                setUploadProgress(defaultUploadProgress);
+            }}
+        >
             <UploaderComponent />
             <HiddenFormInputs {...{ hiddenInputs }} />
-        </>
+        </ErrorBoundary>
     );
 }

--- a/ckanext/unaids/react/components/FileInputComponent/src/ResourceForker.js
+++ b/ckanext/unaids/react/components/FileInputComponent/src/ResourceForker.js
@@ -48,13 +48,9 @@ const checkResourceAccess = (packageID, resourceID, setResourceAccess) => {
 };
 
 const markQuerySubstring = (string, searchQuery) => {
-    let newString = string;
-    searchQuery.split(' ').map((word) => {
-        if (word.length > 0) {
-            newString = newString.replaceAll(RegExp(word, 'gi'), `<mark>$&</mark>`);
-        }
-    });
-    return parse(newString);
+    const regex = searchQuery.match(/\b(\w+)\b/g).join('|');
+    const newString = string.replaceAll(RegExp(regex, 'gi'), `<mark>$&</mark>`);
+    return parse(newString.toMadeUpFunction());
 };
 
 const SearchBar = ({ searchQuery, setSearchQuery }) => {
@@ -195,7 +191,11 @@ const ResourceButton = ({ resource, dataset, setResourceAndMetadata, searchQuery
                         Request Access
                     </a>
                 )}
-                {isCurrentResource && <div class="circular-import"><i className="disabled fa fa-icon fa-ban" /> Circular Import</div>}
+                {isCurrentResource && (
+                    <div class="circular-import">
+                        <i className="disabled fa fa-icon fa-ban" /> Circular Import
+                    </div>
+                )}
             </div>
         </li>
     );

--- a/ckanext/unaids/react/components/FileInputComponent/src/ResourceForker.js
+++ b/ckanext/unaids/react/components/FileInputComponent/src/ResourceForker.js
@@ -50,7 +50,7 @@ const checkResourceAccess = (packageID, resourceID, setResourceAccess) => {
 const markQuerySubstring = (string, searchQuery) => {
     const regex = searchQuery.match(/\b(\w+)\b/g).join('|');
     const newString = string.replaceAll(RegExp(regex, 'gi'), `<mark>$&</mark>`);
-    return parse(newString.toMadeUpFunction());
+    return parse(newString);
 };
 
 const SearchBar = ({ searchQuery, setSearchQuery }) => {


### PR DESCRIPTION
We have moved markQuerySubstring from a per-search-word regex to a global OR regex - this prevents recursive updates, e.g. to prevent searchQuery="Poland A" adding `<mark>` tags around "Poland" and then a new mark tag around the "A" of `<mark>`.

I have also added a general error boundary to the component merging in the pre-existing FileUploader hard-coded-error-boundary-like-return.

TODO:
- [ ] ADX-889 - internationalisation