### PR TITLE
ADX-910 Only update resource format if a format is defined

### DIFF
--- a/ckanext/unaids/react/components/FileInputComponent/src/App.js
+++ b/ckanext/unaids/react/components/FileInputComponent/src/App.js
@@ -100,7 +100,7 @@ export default function App({
                         // url field is handled by input field in UI
                     };
                 case 'resource':
-                    if (fileFormatField) fileFormatField.value = metadata.format;
+                    if (fileFormatField && 'format' in metadata) fileFormatField.value = metadata.format;
                     return {
                         url_type: null,
                         lfs_prefix: null,


### PR DESCRIPTION
The resource forker, in some undeterministic manner, seems to set the resource format to “undefined”.

After quite a lot of further digging I have realised that there is a race condition between autocomplete.js and the fileinputcomponent.js.

If autocomplete loads fast, there is not a problem, but if it loads slow we see the resource format is set as “undefined” and nothing can change it out of that. 

After blocking autocomplete.js from loading I traced the problem down to this line: https://github.com/fjelltopp/ckanext-unaids/blob/82a8d5aac62157dca5c695c79c1ff38ceb4fb811/ckanext/unaids/react/components/FileInputComponent/src/App.js#L103

The “undefined” was coming from occasions that this function was called with metadata that did not include a format. 

My fix is basically to only update the format if a metadata.format value is defined.