### PR TITLE
Add hidden passwords field for CKAN to not crash when updating About text or upload a new Profile Picture

### DIFF
--- a/ckanext/unaids/theme/templates/user/edit_user_form.html
+++ b/ckanext/unaids/theme/templates/user/edit_user_form.html
@@ -34,6 +34,12 @@
 
   </fieldset>
 
+   <div>
+      <input type="hidden" name="old_password"/>
+      <input type="hidden" name="password1"/>
+      <input type="hidden" name="password2"/>
+  </div>
+
   <div class="form-actions">
     {% block delete_button %}
       {% if h.check_access('user_delete', {'id': data.id})  %}


### PR DESCRIPTION
Minimal changes in the template **edit_user_form.html**, I added back 3 old passwords inputs but as hidden;
Did not use `form.input() `due to it adding a label tag before the input.

