### PR TITLE
Adx 972 show 100 organisations on a single page

### DIFF
--- a/ckanext/unaids/blueprints/__init__.py
+++ b/ckanext/unaids/blueprints/__init__.py
@@ -3,6 +3,7 @@ from ckanext.unaids.blueprints.unaids_dataset_transfer import unaids_dataset_tra
 from ckanext.unaids.blueprints.user_info_blueprint import user_info_blueprint
 from ckanext.unaids.blueprints.unaids_dataset_releases import unaids_dataset_releases
 from ckanext.unaids.blueprints.login_register_catch import login_register_catch
+from ckanext.unaids.blueprints.organizations_per_pages import organizations_per_pages
 
 blueprints = [
     unaids_dataset_transfer,
@@ -10,4 +11,5 @@ blueprints = [
     unaids_dataset_releases,
     svg_map_options,
     login_register_catch,
+    organizations_per_pages,
 ]

--- a/ckanext/unaids/blueprints/organizations_per_pages.py
+++ b/ckanext/unaids/blueprints/organizations_per_pages.py
@@ -1,7 +1,10 @@
 
-import ckan.plugins.toolkit as toolkit
 from flask import Blueprint
-from ckan.views.group import *
+from ckan.views.group import set_org
+import ckan.lib.helpers as h
+from ckan.common import g, config, request, _
+import ckan.model as model
+import ckan.lib.base as base
 from ckan.views.group import _check_access, _action, _get_group_template, _guess_group_type
 
 
@@ -92,6 +95,3 @@ def index():
     g.page = extra_vars["page"]
     return base.render(
         _get_group_template(u'index_template', group_type), extra_vars)
-
-
-

--- a/ckanext/unaids/blueprints/organizations_per_pages.py
+++ b/ckanext/unaids/blueprints/organizations_per_pages.py
@@ -9,6 +9,8 @@ organizations_per_pages = Blueprint("organization_pagination", __name__)
 
 
 # both of these are needed to override the default ckan group controller
+# Method below is copied from ckan/views/group.py with the only change being
+# the number of organizations per page
 @organizations_per_pages.route('/organization')
 @organizations_per_pages.route('/organization/')
 def index():

--- a/ckanext/unaids/blueprints/organizations_per_pages.py
+++ b/ckanext/unaids/blueprints/organizations_per_pages.py
@@ -1,0 +1,95 @@
+
+import ckan.plugins.toolkit as toolkit
+from flask import Blueprint
+from ckan.views.group import *
+from ckan.views.group import _check_access, _action, _get_group_template, _guess_group_type
+
+
+organizations_per_pages = Blueprint("organization_pagination", __name__)
+
+
+# both of these are needed to override the default ckan group controller
+@organizations_per_pages.route('/organization')
+@organizations_per_pages.route('/organization/')
+def index():
+    group_type = "organization"
+    extra_vars = {}
+    set_org(True)
+    page = h.get_page_number(request.params) or 1
+    items_per_page = int(config.get(u'ckan.organizations_per_page', 100))
+
+    context = {
+        u'model': model,
+        u'session': model.Session,
+        u'user': g.user,
+        u'for_view': True,
+        u'with_private': False
+    }
+
+    try:
+        _check_access(u'site_read', context)
+        _check_access(u'group_list', context)
+    except NotAuthorized:
+        base.abort(403, _(u'Not authorized to see this page'))
+
+    q = request.params.get(u'q', u'')
+    sort_by = request.params.get(u'sort')
+
+    g.q = q
+    g.sort_by_selected = sort_by
+
+    extra_vars["q"] = q
+    extra_vars["sort_by_selected"] = sort_by
+
+    # pass user info to context as needed to view private datasets of
+    # orgs correctly
+    if g.userobj:
+        context['user_id'] = g.userobj.id
+        context['user_is_admin'] = g.userobj.sysadmin
+
+    try:
+        data_dict_global_results = {
+            u'all_fields': False,
+            u'q': q,
+            u'sort': sort_by,
+            u'type': group_type or u'group',
+        }
+        global_results = _action(u'group_list')(context,
+                                                data_dict_global_results)
+    except ValidationError as e:
+        if e.error_dict and e.error_dict.get(u'message'):
+            msg = e.error_dict['message']
+        else:
+            msg = str(e)
+        h.flash_error(msg)
+        extra_vars["page"] = h.Page([], 0)
+        extra_vars["group_type"] = group_type
+        return base.render(
+            _get_group_template(u'index_template', group_type), extra_vars)
+
+    data_dict_page_results = {
+        u'all_fields': True,
+        u'q': q,
+        u'sort': sort_by,
+        u'type': group_type or u'group',
+        u'limit': items_per_page,
+        u'offset': items_per_page * (page - 1),
+        u'include_extras': True
+    }
+    page_results = _action(u'group_list')(context, data_dict_page_results)
+
+    extra_vars["page"] = h.Page(
+        collection=global_results,
+        page=page,
+        url=h.pager_url,
+        items_per_page=items_per_page, )
+
+    extra_vars["page"].items = page_results
+    extra_vars["group_type"] = group_type
+
+    g.page = extra_vars["page"]
+    return base.render(
+        _get_group_template(u'index_template', group_type), extra_vars)
+
+
+

--- a/ckanext/unaids/theme/templates/organization/index.html
+++ b/ckanext/unaids/theme/templates/organization/index.html
@@ -1,0 +1,43 @@
+{% extends "page.html" %}
+
+{% block subtitle %}{{ _('Organizations') }}{% endblock %}
+
+{% block breadcrumb_content %}
+  <li class="active">{% link_for _('Organizations'), named_route=group_type+'.index' %}</li>
+{% endblock %}
+
+{% block page_header %}{% endblock %}
+
+{% block page_primary_action %}
+  {% if h.check_access('organization_create') %}
+    {% link_for _('Add Organization'), named_route=group_type+'.new', class_='btn btn-primary', icon='plus-square' %}
+  {% endif %}
+{% endblock %}
+
+{% block primary_content_inner %}
+  <h1 class="hide-heading">{% block page_heading %}{{ _('Organizations') }}{% endblock %}</h1>
+  {% block organizations_search_form %}
+    {% snippet 'snippets/search_form.html', form_id='organization-search-form', type='organization', query=q, sorting_selected=sort_by_selected, count=page.item_count, placeholder=_('Search organizations...'), show_empty=request.params, no_bottom_border=true if page.items, sorting = [(_('Name Ascending'), 'title asc'), (_('Name Descending'), 'title desc')] %}
+  {% endblock %}
+  {% block organizations_list %}
+    {% if page.items or request.params %}
+      {% if page.items %}
+        {% snippet "organization/snippets/organization_list.html", organizations=page.items %}
+      {% endif %}
+    {% else %}
+      <p class="empty">
+        {{ _('There are currently no organizations for this site') }}.
+        {% if h.check_access('organization_create') %}
+          {% link_for _('How about creating one?'), named_route=group_type+'.new' %}</a>.
+        {% endif %}
+      </p>
+    {% endif %}
+  {% endblock %}
+  {% block page_pagination %}
+    {{ page.pager(q=q or '', sort=sort_by_selected or '') }}
+  {% endblock %}
+{% endblock %}
+
+{% block secondary_content %}
+  {% snippet "organization/snippets/helper.html" %}
+{% endblock %}

--- a/ckanext/unaids/theme/templates/organization/snippets/organization_list.html
+++ b/ckanext/unaids/theme/templates/organization/snippets/organization_list.html
@@ -1,0 +1,19 @@
+{#
+Display a grid of organization items.
+
+organizations - A list of organizations.
+
+Example:
+
+    {% snippet "organization/snippets/organization_list.html" %}
+
+#}
+{% block organization_list %}
+<ul class="media-grid" data-module="media-grid">
+  {% block organization_list_inner %}
+  {% for organization in organizations %}
+    {% snippet "organization/snippets/organization_item.html", organization=organization, position=loop.index, show_capacity=show_capacity %}
+  {% endfor %}
+   {% endblock %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Adx-972 show 100 organisations on a single page


## Description

Added a blueprint to override the default url /organization in order to have 100 organizations in one single page.
Added a new config ckan.organizations_per_page = 100 in adx_develop ini file

## Checklist


- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
