### PR TITLE
ADX 977 - Invalid filename allowed upon upload

### DIFF
--- a/ckanext/unaids/logic.py
+++ b/ckanext/unaids/logic.py
@@ -34,7 +34,7 @@ def update_filename_in_resource_url(resource):
     if resource['url_type'] == 'upload':
         filename = model.Resource.get(resource['id']).url
         # core CKAN functionality fails for non ascii filenames
-        filename = substitute_ascii_equivalents(filename)
+        filename = substitute_ascii_equivalents(filename).replace('%', '-')
         url_segments = resource['url'].split('/')
         if filename and len(url_segments):
             new_url_segments = url_segments[:-1] + [filename]


### PR DESCRIPTION
## Description

The code replaces any '%' to a '-' in the filename upon upload. 
## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
