### PR TITLE
ADX-984 Fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 giftless-client==0.1.1
 cssmin==0.2.0
 ckanext-saml2auth==1.2.3
+python-dotenv==1.0.0
+python-jose==3.3.0


### PR DESCRIPTION
## ADX-984 Fix requirements

Tests on ckan don't use Pipfile from adx_develop, therefore required libraries need to be defined via requirements.txt file (as done here for: `python-dotenv` and `python-jose`).