### PR TITLE
ADX-984 OAuth2 ADR authorization bugfix

### DIFF
--- a/ckanext/unaids/auth_logic.py
+++ b/ckanext/unaids/auth_logic.py
@@ -43,7 +43,7 @@ directlyProvides(json_response_omitting_challenge_decider, IChallengeDecider)
 # based on work from https://auth0.com/docs/quickstart/backend/python/01-authorization
 def access_token_present_and_valid_and_user_authorized():
     token = request.headers.get('Authorization', '')
-    if token:
+    if token and token.startswith("Bearer "):
         access_token = validate_and_decode_token(token)
         verify_required_scope(access_token)
         subject = access_token['sub']
@@ -102,9 +102,7 @@ def extract_token(encoded_token):
     """
     parts = encoded_token.split()
 
-    if parts[0].lower() != "bearer":
-        raise OAuth2AuthenticationError(message="Authorization header must start with Bearer")
-    elif len(parts) == 1:
+    if len(parts) == 1:
         raise OAuth2AuthenticationError(message="Token not found")
     elif len(parts) > 2:
         raise OAuth2AuthenticationError(message="Authorization header must be Bearer token")

--- a/ckanext/unaids/tests/test_auth_logic.py
+++ b/ckanext/unaids/tests/test_auth_logic.py
@@ -24,10 +24,6 @@ class TestExtractToken(object):
     def test_should_pass_when_right_token(self):
         assert auth_logic.extract_token("Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6I") == "eyJhbGciOiJSUzI1NiIsInR5cCI6I"
 
-    def test_should_throw_when_not_bearer(self):
-        with pytest.raises(auth_logic.OAuth2AuthenticationError, match="Authorization header must start with Bearer"):
-            auth_logic.extract_token("User")
-
     def test_should_throw_when_more_than_2_parts(self):
         with pytest.raises(auth_logic.OAuth2AuthenticationError, match="Authorization header must be Bearer token"):
             auth_logic.extract_token("Bearer ey2323 ddd")


### PR DESCRIPTION
## ADX-984 OAuth2 ADR authorization bugfix

Adjust OAuth2 token validation, so it is done only if 'Authorization' header value starts with 'Bearer ' (previously it wasn't checked so whenever 'Authorization' header appeared OAuth2 validation code was fired). After this step CKAN's API Key and API Token validation can be performed.

## Testing (delete if not applicable)

Tests adjusted accordingly.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
