### PR TITLE
FIP-36 Bump versions based on PR labels with actions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,19 @@
+name: Bump versions based on labels
+
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+        types:
+            - labeled
+
+jobs:
+    labeler:
+        runs-on: ubuntu-latest
+        steps:
+            - name: checkout
+              uses: actions/checkout@v2
+            - name: bump version
+              uses: haya14busa/action-bumpr@v1
+              

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -16,4 +16,6 @@ jobs:
               uses: actions/checkout@v2
             - name: bump version
               uses: haya14busa/action-bumpr@v1
+              with:
+                default_bump_level: "patch"
               

--- a/.github/workflows/synchronise-labels.yml
+++ b/.github/workflows/synchronise-labels.yml
@@ -1,0 +1,20 @@
+name: Set Repo Label List
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: '00 00 * * *'
+
+jobs:
+    labeler:
+        runs-on: ubuntu-latest
+        steps:
+            - name: checkout
+              uses: actions/checkout@v2
+            - name: synchronize labels
+              uses: julbme/gh-action-manage-label@v1
+              with:
+                  from: https://raw.githubusercontent.com/fjelltopp/.github/main/.github/labels.yml
+                  skip-delete: true
+              env:
+                  GITHUB_TOKEN: ${{ secrets.ROBOT_TOKEN  }}

--- a/.github/workflows/synchronise-labels.yml
+++ b/.github/workflows/synchronise-labels.yml
@@ -14,7 +14,7 @@ jobs:
             - name: synchronize labels
               uses: julbme/gh-action-manage-label@v1
               with:
-                  from: https://raw.githubusercontent.com/fjelltopp/.github/main/.github/labels.yml
+                  from: https://raw.githubusercontent.com/fjelltopp/.github/master/.github/labels.yml
                   skip-delete: true
               env:
                   GITHUB_TOKEN: ${{ secrets.ROBOT_TOKEN  }}

--- a/.github/workflows/synchronise-labels.yml
+++ b/.github/workflows/synchronise-labels.yml
@@ -17,4 +17,4 @@ jobs:
                   from: https://raw.githubusercontent.com/fjelltopp/.github/master/.github/labels.yml
                   skip-delete: true
               env:
-                  GITHUB_TOKEN: ${{ secrets.ROBOT_TOKEN  }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}


### PR DESCRIPTION
## Description

As discussed on Jira I have used (bumpr)[https://github.com/marketplace/actions/bumpr-bump-version-when-merging-pull-request-with-specific-labels] to set up GitHub actions that will automatically update tags with the next semantic version number based on labels that people can add to the PR.

When this PR is merged you will need to wait for the synchronise-labels Action to run before the labels with appear. This happens at midnight by default but you can also run it directly from the GitHub Actions interface.

## Testing

At the moment this is not really tested because I would need admin authority. But it is fairly simple and I am quietly confident it will work.

## Checklist

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
