### PR TITLE
Adx 1028 rename to profile editor

### DIFF
--- a/ckanext/unaids/blueprints/__init__.py
+++ b/ckanext/unaids/blueprints/__init__.py
@@ -3,7 +3,7 @@ from ckanext.unaids.blueprints.unaids_dataset_transfer import unaids_dataset_tra
 from ckanext.unaids.blueprints.user_info_blueprint import user_info_blueprint
 from ckanext.unaids.blueprints.unaids_dataset_releases import unaids_dataset_releases
 from ckanext.unaids.blueprints.login_register_catch import login_register_catch
-from ckanext.unaids.blueprints.ape_data_receiver import ape_data_receiver
+from ckanext.unaids.blueprints.profile_editor_data_receiver import profile_editor_data_receiver
 
 blueprints = [
     unaids_dataset_transfer,
@@ -11,5 +11,5 @@ blueprints = [
     unaids_dataset_releases,
     svg_map_options,
     login_register_catch,
-    ape_data_receiver
+    profile_editor_data_receiver
 ]

--- a/ckanext/unaids/blueprints/profile_editor_data_receiver.py
+++ b/ckanext/unaids/blueprints/profile_editor_data_receiver.py
@@ -4,10 +4,10 @@ from ckan.lib.helpers import url_for
 from ckan.plugins import toolkit
 
 
-ape_data_receiver = Blueprint("ape_data_receiver", __name__)
+profile_editor_data_receiver = Blueprint("profile_editor_data_receiver", __name__)
 
 
-@ape_data_receiver.route('/ape_data_receiver', methods=['GET'])
+@profile_editor_data_receiver.route('/profile_editor_data_receiver', methods=['GET'])
 def receive():
     if not g.user:
         return toolkit.abort(403, _('You must be logged in to access this page'))

--- a/ckanext/unaids/helpers.py
+++ b/ckanext/unaids/helpers.py
@@ -121,10 +121,10 @@ def get_bulk_file_uploader_default_fields():
     return toolkit.config.get(BULK_FILE_UPLOADER_DEFAULT_FIELDS, {})
 
 
-def get_ape_url():
+def get_profile_editor_url():
     query_params = {
         "back_url": full_current_url(),
-        "after_save_url": _get_ape_save_callback(),
+        "after_save_url": _get_profile_editor_save_callback(),
         "lang": get_lang()
     }
     domain_part = config.get("ckanext.unaids.ape_url", "")
@@ -289,10 +289,10 @@ def unaids_get_validation_badge(resource, in_listing=False):
     return badge_html
 
 
-def _get_ape_save_callback():
+def _get_profile_editor_save_callback():
     default_locale = config.get("ckan.locale_default")
     current_lang = lang()
     site_url = config.get("ckan.site_url")
     lang_in_url = ("/" + current_lang) if current_lang and current_lang != default_locale else ""
 
-    return f"{site_url}{lang_in_url}/ape_data_receiver"
+    return f"{site_url}{lang_in_url}/profile_editor_data_receiver"

--- a/ckanext/unaids/helpers.py
+++ b/ckanext/unaids/helpers.py
@@ -127,7 +127,7 @@ def get_profile_editor_url():
         "after_save_url": _get_profile_editor_save_callback(),
         "lang": get_lang()
     }
-    domain_part = config.get("ckanext.unaids.ape_url", "")
+    domain_part = config.get("ckanext.unaids.profile_editor_url", "")
     encoded_query_params = urlencode(query_params)
 
     return f"{domain_part}?{encoded_query_params}"

--- a/ckanext/unaids/i18n/fr/LC_MESSAGES/ckanext-unaids.po
+++ b/ckanext/unaids/i18n/fr/LC_MESSAGES/ckanext-unaids.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: info@fjelltopp.org\n"
-"POT-Creation-Date: 2023-08-10 10:59+0000\n"
+"POT-Creation-Date: 2023-08-10 11:59+0000\n"
 "PO-Revision-Date: 2020-12-14 12:15+0300\n"
 "Last-Translator: Toavina A. <toavina@fjelltopp.org>\n"
 "Language: fr\n"
@@ -78,7 +78,7 @@ msgstr "Année"
 msgid "Location"
 msgstr "Lieu"
 
-#: ckanext/unaids/plugin.py:296
+#: ckanext/unaids/plugin.py:295
 msgid "Data Explorer"
 msgstr "Explorateur de données"
 
@@ -113,11 +113,11 @@ msgstr "iframe"
 msgid ",m[42]="
 msgstr ",m[42]="
 
-#: ckanext/unaids/blueprints/ape_data_receiver.py:13
+#: ckanext/unaids/blueprints/profile_editor_data_receiver.py:13
 msgid "You must be logged in to access this page"
 msgstr "Vous devez être connecté pour accéder à cette page"
 
-#: ckanext/unaids/blueprints/ape_data_receiver.py:15
+#: ckanext/unaids/blueprints/profile_editor_data_receiver.py:15
 msgid ""
 "User profile successfully saved, you need to log in again to see the "
 "changes."

--- a/ckanext/unaids/i18n/pt_PT/LC_MESSAGES/ckanext-unaids.po
+++ b/ckanext/unaids/i18n/pt_PT/LC_MESSAGES/ckanext-unaids.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-unaids 0.0\n"
 "Report-Msgid-Bugs-To: info@fjelltopp.org\n"
-"POT-Creation-Date: 2023-08-10 10:59+0000\n"
+"POT-Creation-Date: 2023-08-10 11:59+0000\n"
 "PO-Revision-Date: 2022-01-11 08:31+0000\n"
 "Last-Translator: Toavina A. <toavina@fjelltopp.org>\n"
 "Language: pt_PT\n"
@@ -76,7 +76,7 @@ msgstr "Ano"
 msgid "Location"
 msgstr "Localização"
 
-#: ckanext/unaids/plugin.py:296
+#: ckanext/unaids/plugin.py:295
 msgid "Data Explorer"
 msgstr "Explorador de dados"
 
@@ -111,11 +111,11 @@ msgstr "iframe"
 msgid ",m[42]="
 msgstr ",m[42]="
 
-#: ckanext/unaids/blueprints/ape_data_receiver.py:13
+#: ckanext/unaids/blueprints/profile_editor_data_receiver.py:13
 msgid "You must be logged in to access this page"
 msgstr "Você precisa estar conectado para acessar esta página"
 
-#: ckanext/unaids/blueprints/ape_data_receiver.py:15
+#: ckanext/unaids/blueprints/profile_editor_data_receiver.py:15
 msgid ""
 "User profile successfully saved, you need to log in again to see the "
 "changes."

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -33,7 +33,7 @@ from ckanext.unaids.helpers import (
     get_google_analytics_id,
     is_an_estimates_dataset,
     url_encode,
-    get_ape_url,
+    get_profile_editor_url,
     unaids_get_validation_badge
 )
 import ckanext.blob_storage.helpers as blobstorage_helpers
@@ -151,7 +151,7 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
             "get_google_analytics_id": get_google_analytics_id,
             "is_an_estimates_dataset": is_an_estimates_dataset,
             "url_encode": url_encode,
-            "get_ape_url": get_ape_url,
+            "get_profile_editor_url": get_profile_editor_url,
             "unaids_get_validation_badge": unaids_get_validation_badge,
         }
 

--- a/ckanext/unaids/theme/templates/user/edit_user_form.html
+++ b/ckanext/unaids/theme/templates/user/edit_user_form.html
@@ -23,7 +23,7 @@
         </div>
           <div class="row">
           <div class="col-xs-12 text-right no-bottom-padding">
-            <a class="btn btn-primary" href="{{ h.get_ape_url() }}">{{ _('Update data') }}</a>
+            <a class="btn btn-primary" href="{{ h.get_profile_editor_url() }}">{{ _('Update data') }}</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## ADX 1028 Rename to Profile Editor

Change all occurrences of previous name of Profile Editor to its current.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
