### PR TITLE
ADX-1041 redirect to profile_editor if missing user affiliation profile details

### DIFF
--- a/ckanext/unaids/blueprints/__init__.py
+++ b/ckanext/unaids/blueprints/__init__.py
@@ -4,6 +4,7 @@ from ckanext.unaids.blueprints.user_info_blueprint import user_info_blueprint
 from ckanext.unaids.blueprints.unaids_dataset_releases import unaids_dataset_releases
 from ckanext.unaids.blueprints.login_register_catch import login_register_catch
 from ckanext.unaids.blueprints.profile_editor_data_receiver import profile_editor_data_receiver
+from ckanext.unaids.blueprints.validate_user_affiliation import validate_user_affiliation
 
 blueprints = [
     unaids_dataset_transfer,
@@ -11,5 +12,6 @@ blueprints = [
     unaids_dataset_releases,
     svg_map_options,
     login_register_catch,
-    profile_editor_data_receiver
+    profile_editor_data_receiver,
+    validate_user_affiliation,
 ]

--- a/ckanext/unaids/blueprints/validate_user_affiliation.py
+++ b/ckanext/unaids/blueprints/validate_user_affiliation.py
@@ -1,0 +1,50 @@
+# encoding: utf-8
+import logging
+import ckan.lib.helpers as h
+from flask import Blueprint
+from ckan.common import g, _
+from ckan.plugins import toolkit
+from ckanext.unaids import helpers
+from ckanext.unaids.custom_user_profile import validate_plugin_extras_provided
+
+log = logging.getLogger(__name__)
+
+validate_user_affiliation = Blueprint(
+    'validate_user_affiliation',
+    __name__,
+    url_prefix = '/validate-user-affiliation'
+)
+
+
+@validate_user_affiliation.route('/')
+def check_user_affiliation():
+    """
+    Check if user profile has the custom fields, as defined by this plugin.
+    """
+    try:
+        user_profile = g.userobj
+    except Exception:
+        return h.redirect_to(controller='saml2auth', action='saml2login', id=None, came_from="/validate-user-affiliation/")
+
+    try:
+        user_profile_dict = user_profile.as_dict()
+        plugin_extras = user_profile_dict.get('plugin_extras', {})
+        unaids_extras = plugin_extras.get('unaids', {})
+        validate_plugin_extras_provided(unaids_extras)
+    except (toolkit.ValidationError, AttributeError):
+        return h.redirect_to(helpers.get_profile_editor_url(
+            after_save_url=h.url_for("validate_user_affiliation.success_callback"),
+            back_url=h.url_for('dashboard.index'),
+            flash_message=_("UNAIDS requests that further information be added "
+            "to your user profile. Please complete the required "
+            "fields below before continuing...")
+        ))
+
+    return h.redirect_to('dashboard.index')
+
+@validate_user_affiliation.route('/success-callback/')
+def success_callback():
+    h.flash_success(
+        _("Thank you for updating your profile information.")
+    )
+    return h.redirect_to('dashboard.index')

--- a/ckanext/unaids/blueprints/validate_user_affiliation.py
+++ b/ckanext/unaids/blueprints/validate_user_affiliation.py
@@ -33,11 +33,11 @@ def check_user_affiliation():
         validate_plugin_extras_provided(unaids_extras)
     except (toolkit.ValidationError, AttributeError):
         return h.redirect_to(helpers.get_profile_editor_url(
-            after_save_url=h.url_for("validate_user_affiliation.success_callback"),
-            back_url=h.url_for('dashboard.index'),
-            flash_message=_("UNAIDS requests that further information be added "
+            after_save_url=h.url_for("validate_user_affiliation.success_callback", _external=True),
+            back_url=h.url_for('dashboard.index', _external=True),
+            flash_message=_("UNAIDS asks that further information be added "
             "to your user profile. Please complete the required "
-            "fields below before continuing...")
+            "fields missing below before continuing...")
         ))
 
     return h.redirect_to('dashboard.index')

--- a/ckanext/unaids/blueprints/validate_user_affiliation.py
+++ b/ckanext/unaids/blueprints/validate_user_affiliation.py
@@ -36,11 +36,12 @@ def check_user_affiliation():
             after_save_url=h.url_for("validate_user_affiliation.success_callback", _external=True),
             back_url=h.url_for('dashboard.index', _external=True),
             flash_message=_("UNAIDS asks that further information be added "
-                "to your user profile. Please complete the required "
-                "fields missing below before continuing...")
+                                "to your user profile. Please complete the required "
+                                "fields missing below before continuing...")
         ))
 
     return h.redirect_to('dashboard.index')
+
 
 @validate_user_affiliation.route('/success-callback/')
 def success_callback():

--- a/ckanext/unaids/blueprints/validate_user_affiliation.py
+++ b/ckanext/unaids/blueprints/validate_user_affiliation.py
@@ -36,8 +36,8 @@ def check_user_affiliation():
             after_save_url=h.url_for("validate_user_affiliation.success_callback", _external=True),
             back_url=h.url_for('dashboard.index', _external=True),
             flash_message=_("UNAIDS asks that further information be added "
-                                "to your user profile. Please complete the required "
-                                "fields missing below before continuing...")
+                            "to your user profile. Please complete the required "
+                            "fields missing below before continuing...")
         ))
 
     return h.redirect_to('dashboard.index')

--- a/ckanext/unaids/blueprints/validate_user_affiliation.py
+++ b/ckanext/unaids/blueprints/validate_user_affiliation.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 validate_user_affiliation = Blueprint(
     'validate_user_affiliation',
     __name__,
-    url_prefix = '/validate-user-affiliation'
+    url_prefix='/validate-user-affiliation'
 )
 
 
@@ -36,8 +36,8 @@ def check_user_affiliation():
             after_save_url=h.url_for("validate_user_affiliation.success_callback", _external=True),
             back_url=h.url_for('dashboard.index', _external=True),
             flash_message=_("UNAIDS asks that further information be added "
-            "to your user profile. Please complete the required "
-            "fields missing below before continuing...")
+                "to your user profile. Please complete the required "
+                "fields missing below before continuing...")
         ))
 
     return h.redirect_to('dashboard.index')

--- a/ckanext/unaids/custom_user_profile.py
+++ b/ckanext/unaids/custom_user_profile.py
@@ -58,3 +58,11 @@ def format_plugin_extras(plugin_extras):
     for field in CUSTOM_FIELDS:
         out_dict[field["name"]] = plugin_extras.get(field["name"], field["default"])
     return out_dict
+
+def validate_plugin_extras_provided(data_dict):
+    for field in CUSTOM_FIELDS:
+        if not data_dict.get(field["name"]):
+            pass
+            raise t.ValidationError(
+                {field["name"]: ["Missing value"]}
+            )

--- a/ckanext/unaids/custom_user_profile.py
+++ b/ckanext/unaids/custom_user_profile.py
@@ -59,6 +59,7 @@ def format_plugin_extras(plugin_extras):
         out_dict[field["name"]] = plugin_extras.get(field["name"], field["default"])
     return out_dict
 
+
 def validate_plugin_extras_provided(data_dict):
     for field in CUSTOM_FIELDS:
         if not data_dict.get(field["name"]):

--- a/ckanext/unaids/helpers.py
+++ b/ckanext/unaids/helpers.py
@@ -121,12 +121,13 @@ def get_bulk_file_uploader_default_fields():
     return toolkit.config.get(BULK_FILE_UPLOADER_DEFAULT_FIELDS, {})
 
 
-def get_profile_editor_url():
+def get_profile_editor_url(**extra_query_params):
     query_params = {
         "back_url": full_current_url(),
         "after_save_url": _get_profile_editor_save_callback(),
         "lang": get_lang()
     }
+    query_params.update(extra_query_params)
     domain_part = config.get("ckanext.unaids.profile_editor_url", "")
     encoded_query_params = urlencode(query_params)
 


### PR DESCRIPTION
## Description
1. Updated helpers.get_profile_editor_url to suport custom url args
2. Added new blueprint ckanext/unaids/blueprints/validate_user_affiliation.py with two endpoints:
  i. validate_user_affiliation.check_user_affiliation to be set as `ckan.route_after_login` in the ini file
 ii. validate_user_affiliation.success_callback to be used as return url from Profile Editor displaying success message to the user

This change requires:
1. New version of profile editor https://github.com/fjelltopp/auth0_profile_editor/pull/14 needs to be deployed
2. Changes in ckan.ini file in the adx_develop/adx_deploy 

## Internationalisation and Localisation (delete if not applicable)

Do any UI changes require internationalisation (i18n) or localisation (l10n) changes.
If new translations are required, have you created new Jira tickets for each language and informed the appropriate project manager?

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
