### PR TITLE
ADX-1053 Show affiliation details in output of user_list

### DIFF
--- a/ckanext/unaids/actions.py
+++ b/ckanext/unaids/actions.py
@@ -237,7 +237,7 @@ def user_show(original_action, context, data_dict):
 def user_list(original_action, context, data_dict):
     users = original_action(context, data_dict)
     for user in users:
-        if type(user) == dict:
+        if type(user) is dict:
             user_obj = custom_user_profile.get_user_obj({
                 'model': context['model'],
                 'user': user['name']

--- a/ckanext/unaids/actions.py
+++ b/ckanext/unaids/actions.py
@@ -232,5 +232,21 @@ def user_show(original_action, context, data_dict):
     return user
 
 
+@logic.side_effect_free
+@t.chained_action
+def user_list(original_action, context, data_dict):
+    users = original_action(context, data_dict)
+    for user in users:
+        if type(user) == dict:
+            user_obj = custom_user_profile.get_user_obj({
+                'model': context['model'],
+                'user': user['name']
+            })
+            extras = custom_user_profile.init_plugin_extras(user_obj.plugin_extras)
+            extras = custom_user_profile.format_plugin_extras(extras["unaids"])
+            user.update(extras)
+    return users
+
+
 def time_ago_from_timestamp(context, data_dict):
     return t.h.time_ago_from_timestamp(data_dict.get('timestamp'))

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -120,6 +120,7 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
             "user_show_me": actions.user_show_me,
             "populate_data_dictionary": actions.populate_data_dictionary,
             "user_show": actions.user_show,
+            "user_list": actions.user_list,
             "time_ago_from_timestamp": actions.time_ago_from_timestamp,
         }
 

--- a/ckanext/unaids/tests/test_actions.py
+++ b/ckanext/unaids/tests/test_actions.py
@@ -260,4 +260,4 @@ class TestUserAffiliation(object):
                 },
             )
         response = call_action("user_list", all_fields=False)
-        assert response == ['test-user-0', 'test-user-1', 'test-user-2', 'test-user-3']
+        assert set(response) == {'test-user-0', 'test-user-1', 'test-user-2', 'test-user-3'}

--- a/ckanext/unaids/tests/test_actions.py
+++ b/ckanext/unaids/tests/test_actions.py
@@ -229,3 +229,35 @@ class TestUserAffiliation(object):
         response = call_action("user_show", id=user["id"])
         assert response.get("job_title", False) == "Data Scientist"
         assert response.get("affiliation", False) == "Fjelltopp"
+
+    def test_user_list_all_fields_with_affiliation(self):
+        for i in range(4):
+            user = factories.User(name=f"test-user-{i}")
+            user_obj = model.User.get(user["id"])
+
+            read_saml_profile(
+                user_obj,
+                {
+                    "job_title": ["Data Scientist"],
+                    "affiliation": ["Fjelltopp"],
+                },
+            )
+        response = call_action("user_list")
+        for user in response:
+            assert user.get("job_title", False) == "Data Scientist"
+            assert user.get("affiliation", False) == "Fjelltopp"
+
+    def test_user_list_usernames(self):
+        for i in range(4):
+            user = factories.User(name=f"test-user-{i}")
+            user_obj = model.User.get(user["id"])
+
+            read_saml_profile(
+                user_obj,
+                {
+                    "job_title": ["Data Scientist"],
+                    "affiliation": ["Fjelltopp"],
+                },
+            )
+        response = call_action("user_list", all_fields=False)
+        assert response == ['test-user-0', 'test-user-1', 'test-user-2', 'test-user-3']


### PR DESCRIPTION
## Description

The CKAN action `user_list` is not returning the affiliation details added as extra user fields. 

It should do.

In particular it is needed to efficiently fetch user affiliation details as part of the adx_toolbox script `list_users_by_org.py`


## Testing

Tests included, including a test to check it works with both `all_fields` set to True and False. in one case the user_list is a list of strings, in the other case it is a list of dicts - so the code must handle different response types from the upstream action.  It's therefore worth directly testing.  

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
