### PR TITLE
ADX-1054 Dataset type validating

### DIFF
--- a/ckanext/unaids/actions.py
+++ b/ckanext/unaids/actions.py
@@ -248,5 +248,19 @@ def user_list(original_action, context, data_dict):
     return users
 
 
+@t.chained_action
+def package_create(next_action, context, data_dict):
+    dataset_type = data_dict.get('type', '')
+    valid_types = t.get_action("scheming_dataset_schema_list")(context, {})
+    valid_types = set(valid_types) | {'dataset'}
+    if dataset_type:
+        if dataset_type not in valid_types:
+            raise t.ValidationError(
+                f"Type '{dataset_type}' is invalid, valid types are: '"
+                f"{', '.join(valid_types)}'"
+            )
+    return next_action(context, data_dict)
+
+
 def time_ago_from_timestamp(context, data_dict):
     return t.h.time_ago_from_timestamp(data_dict.get('timestamp'))

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -121,6 +121,7 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
             "populate_data_dictionary": actions.populate_data_dictionary,
             "user_show": actions.user_show,
             "user_list": actions.user_list,
+            "package_create": actions.package_create,
             "time_ago_from_timestamp": actions.time_ago_from_timestamp,
         }
 

--- a/ckanext/unaids/tests/test_actions.py
+++ b/ckanext/unaids/tests/test_actions.py
@@ -14,7 +14,7 @@ from ckanext.unaids.tests import get_context, create_dataset_with_releases
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'unaids blob_storage')
+@pytest.mark.ckan_config('ckan.plugins', 'unaids blob_storage scheming_datasets')
 @pytest.mark.usefixtures('with_plugins')
 class TestGetTableSchema(object):
 
@@ -41,7 +41,7 @@ class TestGetTableSchema(object):
         assert response == {}
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'unaids versions restricted blob_storage')
+@pytest.mark.ckan_config('ckan.plugins', 'unaids versions restricted blob_storage scheming_datasets')
 @pytest.mark.usefixtures('with_plugins')
 class TestDatasetShowForRelease(object):
 
@@ -148,7 +148,7 @@ class TestDatasetShowForRelease(object):
         pytest.fail("Couldn't find user with required role %s", user_role)
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'unaids versions')
+@pytest.mark.ckan_config('ckan.plugins', 'unaids versions scheming_datasets')
 @pytest.mark.usefixtures('with_plugins')
 class TestPackageActivityList(object):
 
@@ -194,7 +194,7 @@ class TestUserShowMe(object):
         assert response['name'] == user['name']
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'unaids')
+@pytest.mark.ckan_config('ckan.plugins', 'unaids scheming_datasets')
 @pytest.mark.usefixtures('with_plugins')
 class TestPopulateDataDictionary(object):
 

--- a/ckanext/unaids/tests/test_actions.py
+++ b/ckanext/unaids/tests/test_actions.py
@@ -261,3 +261,43 @@ class TestUserAffiliation(object):
             )
         response = call_action("user_list", all_fields=False)
         assert set(response) == {'test-user-0', 'test-user-1', 'test-user-2', 'test-user-3'}
+
+
+@pytest.mark.ckan_config('ckan.plugins', 'unaids scheming_datasets')
+@pytest.mark.usefixtures('with_plugins')
+class TestPackageCreate():
+
+    def test_should_complain_with_exception_when_dataset_type_invalid(self):
+        organization = factories.Organization()
+        exception_message = "Type 'baad-type' is invalid, valid types are"
+        with pytest.raises(toolkit.ValidationError, match=exception_message):
+            call_action(
+                'package_create',
+                name="some-name",
+                type="baad-type",
+                owner_org=organization['name'],
+                title="Dataset with missing title"
+            )
+
+    def test_create_dataset_without_type_creates_one_with_default_type_of_dataset(self):
+        organization = factories.Organization()
+        dataset = call_action(
+            'package_create',
+            name="some-name",
+            owner_org=organization['name'],
+            title="Dataset without type"
+        )
+
+        assert dataset["type"] == "dataset"
+
+    def test_create_dataset_with_valid_type(self):
+        organization = factories.Organization()
+        dataset = call_action(
+            'package_create',
+            name="some-name",
+            type="test-schema",
+            title="Dataset with valid type",
+            owner_org=organization['name']
+        )
+
+        assert dataset["type"] == "test-schema"

--- a/ckanext/unaids/tests/test_auth_logic.py
+++ b/ckanext/unaids/tests/test_auth_logic.py
@@ -297,7 +297,7 @@ class TestValidateAndDecodeToken(object):
             auth_logic.validate_and_decode_token(encoded)
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'unaids')
+@pytest.mark.ckan_config('ckan.plugins', 'unaids scheming_datasets')
 @pytest.mark.usefixtures('with_request_context', 'with_plugins', 'clean_db')
 class TestRegressionOAuth2PluginDoesntPreventVanillaCkanAuthentication:
 

--- a/ckanext/unaids/tests/test_dataset_releases.py
+++ b/ckanext/unaids/tests/test_dataset_releases.py
@@ -42,7 +42,7 @@ def assert_releases_are_exactly(user, dataset_id, expected_releases):
 
 
 @pytest.mark.usefixtures('with_plugins')
-@pytest.mark.ckan_config('ckan.plugins', 'unaids blob_storage versions pages')
+@pytest.mark.ckan_config('ckan.plugins', 'unaids blob_storage versions pages scheming_datasets')
 class TestDatasetReleaseCreateAndEdit(object):
 
     def _create_or_edit(self, app, user, dataset, release, activity_id=None):
@@ -138,7 +138,7 @@ class TestDatasetReleaseCreateAndEdit(object):
 
 
 @pytest.mark.usefixtures('with_plugins')
-@pytest.mark.ckan_config('ckan.plugins', 'unaids blob_storage versions pages')
+@pytest.mark.ckan_config('ckan.plugins', 'unaids blob_storage versions pages scheming_datasets')
 class TestDatasetReleaseDelete(object):
 
     def _delete(self, app, user, dataset, release):
@@ -179,7 +179,7 @@ class TestDatasetReleaseDelete(object):
 
 
 @pytest.mark.usefixtures('with_plugins')
-@pytest.mark.ckan_config('ckan.plugins', 'unaids blob_storage versions pages')
+@pytest.mark.ckan_config('ckan.plugins', 'unaids blob_storage versions pages scheming_datasets')
 class TestDatasetReleaseRestore(object):
 
     def _restore(self, app, user, dataset, release):
@@ -223,7 +223,7 @@ class TestDatasetReleaseRestore(object):
 
 
 @pytest.mark.usefixtures('with_plugins')
-@pytest.mark.ckan_config('ckan.plugins', 'unaids blob_storage versions pages')
+@pytest.mark.ckan_config('ckan.plugins', 'unaids blob_storage versions pages scheming_datasets')
 class TestDatasetReleaseListView(object):
 
     def test_no_releases_created(self, app):
@@ -261,7 +261,7 @@ class TestDatasetReleaseListView(object):
 
 
 @pytest.mark.usefixtures('with_plugins')
-@pytest.mark.ckan_config('ckan.plugins', 'unaids blob_storage versions pages')
+@pytest.mark.ckan_config('ckan.plugins', 'unaids blob_storage versions pages scheming_datasets')
 class TestDatasetRead(object):
 
     def _get_dataset_release_sidebar(self, app, user, dataset, activity_id=None):

--- a/ckanext/unaids/tests/test_giftless_backend.py
+++ b/ckanext/unaids/tests/test_giftless_backend.py
@@ -51,7 +51,7 @@ class TestGiftlessBackend(object):
         assert resource.get('name', None) == filename
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'unaids pages blob_storage')
+@pytest.mark.ckan_config('ckan.plugins', 'unaids pages blob_storage scheming_datasets')
 class TestResourceUrlEncoding():
     def test_resource_url_encoding_test(self, app):
         user = factories.User()

--- a/ckanext/unaids/tests/test_logic.py
+++ b/ckanext/unaids/tests/test_logic.py
@@ -52,7 +52,7 @@ def test_validate_resource_upload_fields(lfs_prefix, sha256, size, valid):
         logic.validate_resource_upload_fields(context, resource_dict)
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'unaids authz_service blob_storage')
+@pytest.mark.ckan_config('ckan.plugins', 'unaids authz_service blob_storage scheming_datasets')
 @pytest.mark.usefixtures('with_plugins')
 def test_update_filename_in_upload_resource_url():
     actual_filename = u"TeStè.CSV"
@@ -66,7 +66,7 @@ def test_update_filename_in_upload_resource_url():
     assert resource['url'].endswith(expected_filename)
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'unaids authz_service blob_storage')
+@pytest.mark.ckan_config('ckan.plugins', 'unaids authz_service blob_storage scheming_datasets')
 @pytest.mark.usefixtures('with_plugins')
 @pytest.mark.parametrize("link_url",
                          ["http://link.my", "https://link.my", "https://link.my/path/to/resource"],

--- a/ckanext/unaids/tests/test_plugin.py
+++ b/ckanext/unaids/tests/test_plugin.py
@@ -66,7 +66,7 @@ def resource_with_link_and_updated_metadata():
     return updated_resource
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'unaids blob_storage')
+@pytest.mark.ckan_config('ckan.plugins', 'unaids blob_storage scheming_datasets')
 @pytest.mark.usefixtures('with_plugins')
 class TestPlugin(object):
     '''Tests for the ckanext.example_iauthfunctions.plugin module.


### PR DESCRIPTION
## Description

Ensures that people can only create datasets with a valid scheming type. This solution has been copied over from our spectrum ckan project.  It therefore relates to this PR: https://github.com/fjelltopp/ckanext-spectrum/pull/41

## Testing

Testing suite included The introduction of a scheming action to the package_create action chain means that the `scheming_datasets` plugin needs to be loaded in a number of places across the testing suite. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
