### PR TITLE
Adx 905 add the job title and affiliation to the membership requests

### DIFF
--- a/ckanext/unaids/actions.py
+++ b/ckanext/unaids/actions.py
@@ -274,6 +274,9 @@ def time_ago_from_timestamp(context, data_dict):
 
 @p.toolkit.chained_action
 def member_request_create(next_action, context, data_dict):
+    '''
+    overrides member_request_create action from ckanext-ytp-request plugin, purposely to add job_title and affiliation in the mail sent to the admins
+    '''
     logic.check_access('member_request_create', context, data_dict)
     member = unaids_create_member_request(context, data_dict)
     return model_dictize.member_dictize(member, context)

--- a/ckanext/unaids/actions.py
+++ b/ckanext/unaids/actions.py
@@ -12,6 +12,12 @@ from ckanext.versions.logic.dataset_version_action import get_activity_id_from_d
 from ckanext.unaids.logic import populate_data_dictionary_from_schema
 from ckanext.unaids.helpers import validation_load_json_schema
 
+
+import ckan.plugins as p
+from ckanext.unaids.membership_requests import unaids_create_member_request
+from ckan import model, logic
+from ckan.lib.dictization import model_dictize
+
 NotFound = logic.NotFound
 NotAuthorized = logic.NotAuthorized
 _check_access = logic.check_access
@@ -264,3 +270,10 @@ def package_create(next_action, context, data_dict):
 
 def time_ago_from_timestamp(context, data_dict):
     return t.h.time_ago_from_timestamp(data_dict.get('timestamp'))
+
+
+@p.toolkit.chained_action
+def member_request_create(next_action, context, data_dict):
+    logic.check_access('member_request_create', context, data_dict)
+    member = unaids_create_member_request(context, data_dict)
+    return model_dictize.member_dictize(member, context)

--- a/ckanext/unaids/membership_requests.py
+++ b/ckanext/unaids/membership_requests.py
@@ -1,0 +1,157 @@
+import ckanext.ytp_request.mail as mail
+from ckanext.ytp_request.model import MemberRequest
+from ckan.lib.mailer import mail_user
+from ckan import model, logic
+import ckan.authz as authz
+from ckanext.ytp_request.helper import get_safe_locale
+from ckan.lib.helpers import url_for, flash_success
+import logging
+from ckan.common import _
+from ckan.plugins.toolkit import config
+from flask_babel import force_locale
+
+def unaids_create_member_request(context, data_dict):
+    """ Helper to create member request """
+    role = data_dict.get('role', None)
+    if not role:
+        raise logic.NotFound
+    group = model.Group.get(data_dict.get('group', None))
+
+    if not group or group.type != 'organization':
+        raise logic.NotFound
+
+    user = context.get('user', None)
+
+    if authz.is_sysadmin(user):
+        raise logic.ValidationError({}, {_("Role"): _(
+            "As a sysadmin, you already have access to all organizations")})
+
+    userobj = model.User.get(user)
+    extras = userobj.plugin_extras['unaids']
+    user_job_title = extras.get('job_title', '')
+    user_affiliation = extras.get('affiliation', '')
+
+    member = (model.Session.query(model.Member)
+                           .filter(model.Member.table_name == "user")
+                           .filter(model.Member.table_id == userobj.id)
+                           .filter(model.Member.group_id == group.id).first())
+
+    # If there is a member for this organization and it is NOT deleted. Reuse
+    # existing if deleted
+    if member:
+        if member.state == 'pending':
+            message = _(
+                "You already have a pending request to the organization")
+        elif member.state == 'active':
+            message = _("You are already part of the organization")
+        # Unknown status. Should never happen..
+        elif member.state != 'deleted':
+            raise logic.ValidationError({"organization": _(
+                "Duplicate organization request")}, {_("Organization"): message})
+    else:
+        member = model.Member(table_name="user", table_id=userobj.id, group=group,
+                              group_id=group.id, capacity=role, state='pending')
+
+    # TODO: Is there a way to get language associated to all admins. User table there is nothing as such stored
+    locale = get_safe_locale()
+
+    member.state = 'pending'
+    member.capacity = role
+    member.group = group
+
+    logging.warning("Member's Group ID: " + str(type(member.group_id)))
+    logging.warning(repr(member))
+
+    model.Session.add(member)
+    # We need to flush since we need membership_id (member.id) already
+    model.Session.flush()
+
+    memberRequest = MemberRequest(
+        membership_id=member.id, role=role, status="pending", language=locale)
+    member_id = member.id
+    model.Session.add(memberRequest)
+    model.repo.commit()
+
+    fetched_member = model.Session.query(model.Member).filter(
+        model.Member.id == member_id
+    ).first()
+    logging.warning(repr(group))
+    logging.warning("Fetched member's group ID: " + str(fetched_member.group_id))
+
+    url = config.get('ckan.site_url', "")
+    if url:
+        url = url + url_for('member_request.show', mrequest_id=member.id)
+    # Locale should be admin locale since mail is sent to admins
+    if role == 'admin':
+        for admin in _get_ckan_admins():
+            send_mail_for_new_membership_request(
+                locale, admin, group.display_name, url, userobj.display_name, userobj.email, user_job_title, user_affiliation)
+    else:
+        for admin in _get_organization_admins(group.id):
+            send_mail_for_new_membership_request(
+                locale, admin, group.display_name, url, userobj.display_name, userobj.email, user_job_title, user_affiliation)
+    flash_success(
+        _("Membership request sent to organisation administrator")
+    )
+    return member
+
+
+def send_mail_for_new_membership_request(locale, admin, group_name, url, user_name, user_email, user_job_title, user_affiliation):
+    with force_locale('en'):
+        subject = _SUBJECT_MEMBERSHIP_REQUEST() % {
+            'organization': group_name
+        }
+        message = _MESSAGE_MEMBERSHIP_REQUEST() % {
+            'user': user_name,
+            'email': user_email,
+            'organization': group_name,
+            'link': url,
+            'job_title': user_job_title,
+            'affiliation': user_affiliation
+        }
+
+    try:
+        mail_user(admin, subject, message)
+    except Exception:
+        log.exception("Mail could not be sent")
+
+
+
+
+
+def _SUBJECT_MEMBERSHIP_REQUEST():
+    return _(
+            "New membership request (%(organization)s)")
+
+
+def _MESSAGE_MEMBERSHIP_REQUEST():
+    return _(
+        """\
+        User %(user)s (%(email)s), %(job_title)s at %(affiliation)s, has requested membership to organization %(organization)s.
+
+        %(link)s
+
+        Best wishes,
+        The AIDS Data Repository
+        """
+    )
+
+
+def _get_organization_admins(group_id):
+    admins = set(
+        model.Session.query(model.User)
+        .join(model.Member, model.User.id == model.Member.table_id)
+        .filter(model.Member.table_name == "user")
+        .filter(model.Member.group_id == group_id)
+        .filter(model.Member.state == 'active')
+        .filter(model.Member.capacity == 'admin')
+        .filter(model.User.email != '')
+    )
+
+    admins.update(set(
+        model.Session.query(model.User)
+        .filter(model.User.sysadmin is True)
+        .filter(model.User.email != '')
+        )
+    )
+    return admins

--- a/ckanext/unaids/membership_requests.py
+++ b/ckanext/unaids/membership_requests.py
@@ -95,7 +95,6 @@ def unaids_create_member_request(context, data_dict):
     )
     return member
 
-
 def send_mail_for_new_membership_request(locale, admin, group_name, url, user_name, user_email, user_job_title, user_affiliation):
     with force_locale('en'):
         subject = _SUBJECT_MEMBERSHIP_REQUEST() % {
@@ -115,14 +114,9 @@ def send_mail_for_new_membership_request(locale, admin, group_name, url, user_na
     except Exception:
         log.exception("Mail could not be sent")
 
-
-
-
-
 def _SUBJECT_MEMBERSHIP_REQUEST():
     return _(
             "New membership request (%(organization)s)")
-
 
 def _MESSAGE_MEMBERSHIP_REQUEST():
     return _(

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -123,6 +123,7 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
             "user_list": actions.user_list,
             "package_create": actions.package_create,
             "time_ago_from_timestamp": actions.time_ago_from_timestamp,
+            "member_request_create": actions.member_request_create
         }
 
     def dataset_facets(self, facet_dict, package_type):


### PR DESCRIPTION
## Description

My attempt to add job_title and affiliation in the request membership email from within ckanext-unaids.


## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
