### PR TITLE
ADX-1059 Navigator button

### DIFF
--- a/ckanext/unaids/theme/templates/package/read_base.html
+++ b/ckanext/unaids/theme/templates/package/read_base.html
@@ -3,10 +3,12 @@
 {% block content_action %}
   {% if not is_activity_archive %}
     {% if h.check_access('package_update', {'id':pkg.id }) %}
-      <a class="btn btn-default" href="https://navigator.unaids.org/{{ h.get_language_code() }}/?datasetId={{ pkg.id }}" target="_blank">
-        <i class="fa fa-compass"></i>
-        {{_('Navigator')}}
-      </a>
+      {% if pkg.type == "country-estimates-23" %}
+        <a class="btn btn-default" href="https://navigator.unaids.org/{{ h.get_language_code() }}/?datasetId={{ pkg.id }}" target="_blank">
+          <i class="fa fa-compass"></i>
+          {{_('Navigator')}}
+        </a>
+      {% endif %}
       {% link_for _('Manage'), named_route=pkg.type ~ '.edit', id=pkg.name, class_='btn btn-default', icon='wrench' %}
     {% endif %}
   {% endif %}


### PR DESCRIPTION
## Description

The Navigator button currently shows in the ADR for all datasets but Navigator only works with one dataset type. 

Surely we can take at least some small and quick step to improve this UX fail.

It's not an issue worth taking a lot of time over. Granted there may be better ways of solving the problem (e.g. setting the estimates dataset type in the config file) but I think this PR very quickly puts us in a better place than we are currently. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
