### PR TITLE
ADX-1063 Improve org membership lists

### DIFF
--- a/ckanext/unaids/assets/custom.css
+++ b/ckanext/unaids/assets/custom.css
@@ -878,3 +878,17 @@ div.ckanext-datapreview{
   font-size: 18px;
   margin-top: 1em;
 }
+
+.org-membership.table .avatar{
+  float:left;
+  width: 50px;
+  padding: 5px;
+}
+
+.org-membership.table .details{
+  float:left;
+}
+
+.org-membership.table .membership{
+  width: 175px;
+}

--- a/ckanext/unaids/blueprints/__init__.py
+++ b/ckanext/unaids/blueprints/__init__.py
@@ -5,6 +5,7 @@ from ckanext.unaids.blueprints.unaids_dataset_releases import unaids_dataset_rel
 from ckanext.unaids.blueprints.login_register_catch import login_register_catch
 from ckanext.unaids.blueprints.profile_editor_data_receiver import profile_editor_data_receiver
 from ckanext.unaids.blueprints.validate_user_affiliation import validate_user_affiliation
+from ckanext.unaids.blueprints.user_lists import user_lists
 
 blueprints = [
     unaids_dataset_transfer,
@@ -14,4 +15,5 @@ blueprints = [
     login_register_catch,
     profile_editor_data_receiver,
     validate_user_affiliation,
+    user_lists,
 ]

--- a/ckanext/unaids/blueprints/__init__.py
+++ b/ckanext/unaids/blueprints/__init__.py
@@ -5,7 +5,7 @@ from ckanext.unaids.blueprints.unaids_dataset_releases import unaids_dataset_rel
 from ckanext.unaids.blueprints.login_register_catch import login_register_catch
 from ckanext.unaids.blueprints.profile_editor_data_receiver import profile_editor_data_receiver
 from ckanext.unaids.blueprints.validate_user_affiliation import validate_user_affiliation
-from ckanext.unaids.blueprints.user_lists import user_lists
+from ckanext.unaids.blueprints.members_list import members_list
 
 blueprints = [
     unaids_dataset_transfer,
@@ -15,5 +15,5 @@ blueprints = [
     login_register_catch,
     profile_editor_data_receiver,
     validate_user_affiliation,
-    user_lists,
+    members_list,
 ]

--- a/ckanext/unaids/blueprints/members_list.py
+++ b/ckanext/unaids/blueprints/members_list.py
@@ -5,12 +5,13 @@ import logging
 import pandas
 
 log = logging.getLogger(__name__)
-user_lists = Blueprint(
-    'user_lists',
+members_list = Blueprint(
+    'members_list',
     __name__
 )
 
 
+@members_list.route('/organization/members/<group_id>/download')
 def org_member_download(group_id):
     try:
         toolkit.check_access(
@@ -45,7 +46,6 @@ def org_member_download(group_id):
             toolkit._("ADR Org"): group_id,
             toolkit._("ADR Org Role"): member[2]
         })
-
     df = pandas.DataFrame.from_records(user_list)
     csv = df.to_csv(index=False)
     output = StringIO()
@@ -54,13 +54,7 @@ def org_member_download(group_id):
     filename = toolkit._(f"{group_id}_adr_membership.csv")
     return Response(
                 output,
-                mimetype="application/json",
+                mimetype="text/csv",
                 headers={"Content-disposition":
                          f"attachment; filename={filename}"}
             )
-
-
-user_lists.add_url_rule(
-    '/organization/members/<group_id>/download',
-    view_func=org_member_download
-)

--- a/ckanext/unaids/blueprints/user_lists.py
+++ b/ckanext/unaids/blueprints/user_lists.py
@@ -1,0 +1,55 @@
+import ckan.plugins.toolkit as toolkit
+from flask import Blueprint, Response
+from io import StringIO
+import logging
+import pandas
+import json
+
+log = logging.getLogger(__name__)
+user_lists = Blueprint(
+    'user_lists',
+    __name__
+)
+
+
+def org_member_download(group_id):
+    memberships = toolkit.get_action("member_list")(
+        {},
+        {"id": group_id, "object_type": "user"}
+    )
+    user_list = []
+
+    for member in memberships:
+        user_dict = toolkit.get_action("user_show")(
+            {'keep_email': True},
+            {"id": member[0]}
+        )
+        user_list.append({
+            "username": user_dict.get('name'),
+            "full_name": user_dict.get('fullname'),
+            "email": user_dict.get('email'),
+            "affiliation": user_dict.get("affiliation"),
+            "job_title": user_dict.get('job_title'),
+            "adr_org": group_id,
+            "adr_org_role": member[2]
+        })
+
+    df = pandas.DataFrame.from_records(user_list)
+    csv = df.to_csv(index=False)
+
+    output = StringIO()
+    output.write(csv)
+    output.seek(0)
+
+    return Response(
+                output,
+                mimetype="application/json",
+                headers={"Content-disposition":
+                         "attachment; filename=org_members.csv"}
+            )
+
+
+user_lists.add_url_rule(
+    '/organization/members/<group_id>/download',
+    view_func=org_member_download
+)

--- a/ckanext/unaids/blueprints/user_lists.py
+++ b/ckanext/unaids/blueprints/user_lists.py
@@ -25,27 +25,26 @@ def org_member_download(group_id):
             {"id": member[0]}
         )
         user_list.append({
-            "username": user_dict.get('name'),
-            "full_name": user_dict.get('fullname'),
-            "email": user_dict.get('email'),
-            "affiliation": user_dict.get("affiliation"),
-            "job_title": user_dict.get('job_title'),
-            "adr_org": group_id,
-            "adr_org_role": member[2]
+            toolkit._("Username"): user_dict.get('name'),
+            toolkit._("Full Name"): user_dict.get('fullname'),
+            toolkit._("Email"): user_dict.get('email'),
+            toolkit._("Affiliation"): user_dict.get("affiliation"),
+            toolkit._("Job Title"): user_dict.get('job_title'),
+            toolkit._("ADR Org"): group_id,
+            toolkit._("ADR Org Role"): member[2]
         })
 
     df = pandas.DataFrame.from_records(user_list)
     csv = df.to_csv(index=False)
-
     output = StringIO()
     output.write(csv)
     output.seek(0)
-
+    filename = toolkit._(f"{group_id}_adr_membership.csv")
     return Response(
                 output,
                 mimetype="application/json",
                 headers={"Content-disposition":
-                         "attachment; filename=org_members.csv"}
+                         f"attachment; filename={filename}"}
             )
 
 

--- a/ckanext/unaids/tests/test_blueprints.py
+++ b/ckanext/unaids/tests/test_blueprints.py
@@ -1,6 +1,10 @@
 """Tests for plugin.py."""
 import logging
 import pytest
+import ckan.plugins.toolkit as toolkit
+import pandas
+from numpy import nan
+from io import StringIO
 
 log = logging.getLogger(__name__)
 
@@ -11,3 +15,69 @@ class TestValidateUserProfileBlueprint(object):
     def test_annonymous_access_to_index_page(self, app):
         index_response = app.get("/", follow_redirects=False)
         assert index_response.status_code == 200
+
+
+@pytest.fixture
+def test_org_download(app, test_organization):
+    url = toolkit.url_for(
+        'members_list.org_member_download',
+        group_id=test_organization['name']
+    )
+    org_admin_username = test_organization['users'][0]['name']
+    return app.get(url, extra_environ={'REMOTE_USER': org_admin_username})
+
+
+@pytest.mark.ckan_config("ckan.plugins", "ytp_request unaids pages")
+@pytest.mark.usefixtures("with_plugins")
+class TestMemberLists(object):
+    def test_org_member_download_200_ok(self, test_org_download):
+        assert test_org_download.status_code == 200
+
+    def test_org_member_download_expected_columns(self, test_org_download):
+        df = pandas.read_csv(StringIO(test_org_download.body))
+        expected_columns = {
+            "Username",
+            "Email",
+            "Full Name",
+            "Affiliation",
+            "Job Title",
+            "ADR Org",
+            "ADR Org Role"
+        }
+        assert set(df.columns) == expected_columns
+
+    def test_org_member_download_expected_emails(self, test_org_download):
+        df = pandas.read_csv(StringIO(test_org_download.body))
+        expected_emails = {
+            "admin@ckan.org",
+            "editor@ckan.org",
+            "member@ckan.org",
+            nan
+        }
+        assert set(df['Email']) == expected_emails
+
+    def test_org_member_download_403(self, app, test_organization):
+        url = toolkit.url_for(
+            'members_list.org_member_download',
+            group_id=test_organization['name']
+        )
+        org_editor_username = test_organization['users'][1]['name']
+        response = app.get(url, extra_environ={'REMOTE_USER': org_editor_username})
+        assert response.status_code == 403
+
+    def test_org_member_download_404(self, app, test_organization):
+        url = toolkit.url_for(
+            'members_list.org_member_download',
+            group_id="bad-name"
+        )
+        org_editor_username = test_organization['users'][1]['name']
+        response = app.get(url, extra_environ={'REMOTE_USER': org_editor_username})
+        assert response.status_code == 404
+
+    def test_org_member_download_anonymous_access(self, app, test_organization):
+        url = toolkit.url_for(
+            'members_list.org_member_download',
+            group_id="bad-name"
+        )
+        response = app.get(url)
+        assert response.status_code == 403

--- a/ckanext/unaids/theme/templates/organization/members.html
+++ b/ckanext/unaids/theme/templates/organization/members.html
@@ -3,7 +3,7 @@
 {% block page_primary_action %}
   {{ super() }}
   <a class="btn btn-primary" href="{{h.url_for('user_lists.org_member_download', group_id=organization.name)}}">
-    <i class="fa fa-download"></i> Download Members List</a>
+    <i class="fa fa-download"></i> {{_('Download Members List')}} </a>
 {% endblock %}
 
 {% block primary_content_inner %}

--- a/ckanext/unaids/theme/templates/organization/members.html
+++ b/ckanext/unaids/theme/templates/organization/members.html
@@ -2,7 +2,7 @@
 
 {% block page_primary_action %}
   {{ super() }}
-  <a class="btn btn-primary" href="{{h.url_for('user_lists.org_member_download', group_id=organization.name)}}">
+  <a class="btn btn-primary" href="{{h.url_for('members_list.org_member_download', group_id=organization.name)}}">
     <i class="fa fa-download"></i> {{_('Members\' Emails')}} </a>
 {% endblock %}
 
@@ -45,9 +45,7 @@
   {% endif %}
   {% set count = members|length %}
   {% set members_count = ungettext('{count} member', '{count} members', count).format(count=count) %}
-  {% set show_emails = True %}
   <h3 class="page-heading">{{ members_count }}   </h3>
-
   <table class="table table-header table-hover table-responsive org-membership">
     <thead>
       <tr>

--- a/ckanext/unaids/theme/templates/organization/members.html
+++ b/ckanext/unaids/theme/templates/organization/members.html
@@ -3,7 +3,7 @@
 {% block page_primary_action %}
   {{ super() }}
   <a class="btn btn-primary" href="{{h.url_for('user_lists.org_member_download', group_id=organization.name)}}">
-    <i class="fa fa-download"></i> {{_('Download Members List')}} </a>
+    <i class="fa fa-download"></i> {{_('Members\' Emails')}} </a>
 {% endblock %}
 
 {% block primary_content_inner %}

--- a/ckanext/unaids/theme/templates/organization/members.html
+++ b/ckanext/unaids/theme/templates/organization/members.html
@@ -1,5 +1,11 @@
 {% ckan_extends %}
 
+{% block page_primary_action %}
+  {{ super() }}
+  <a class="btn btn-primary" href="{{h.url_for('user_lists.org_member_download', group_id=organization.name)}}">
+    <i class="fa fa-download"></i> Download Members List</a>
+{% endblock %}
+
 {% block primary_content_inner %}
 {% set member_requests = h.get_member_request_list(organization.id) %}
 {% if member_requests %}
@@ -39,15 +45,15 @@
   {% endif %}
   {% set count = members|length %}
   {% set members_count = ungettext('{count} member', '{count} members', count).format(count=count) %}
-  <h3 class="page-heading">{{ members_count }}</h3>
-  <table class="table table-header table-hover table-bordered">
+  {% set show_emails = True %}
+  <h3 class="page-heading">{{ members_count }}   </h3>
+
+  <table class="table table-header table-hover table-responsive org-membership">
     <thead>
       <tr>
-          <th>{{ _('User') }}</th>
-          <th>{{ _('Job title') }}</th>
-          <th>{{ _('Affiliation') }}</th>
-          <th>{{ _('Role') }}</th>
-          <th></th>
+          <th class="user">{{ _('User') }}</th>
+          <th class="affiliation">{{ _('Affiliation') }}</th>
+          <th class="membership">{{ _('Membership') }}</th>
       </tr>
     </thead>
     <tbody>
@@ -57,12 +63,20 @@
         {% set affiliation = current_member.affiliation if current_member.affiliation is not none else '' %}
         <tr>
           <td class="media">
-            {{ h.linked_user(user_id, maxlength=20) }}
+            <div class="avatar">{{ h.user_image(user_id, 30) }}</div>
+            <div class="details">
+              <a href="{{ h.url_for('user.read', id=user_id) }}">
+                <span> {{current_member.fullname}} </span><br />
+                <span class="small"> ({{current_member.name}}) </span><br />
+              </a>
+              {% if current_member.get("email") %}
+                <span class="small"> {{current_member.email}} </span>
+              {% endif %}
+            </div>
           </td>
-          <td>{{ job_title }}</td>
-          <td>{{ affiliation }}</td>
-          <td>{{ role }}</td>
+          <td>{{ affiliation }} <br /> <span class="small"> {{ job_title }} </span></td>
           <td>
+            {{ role }}
             <div class="btn-group pull-right">
                 <a class="btn btn-default btn-sm" href="{{ h.url_for(group_type + '.member_new', id=group_dict.id, user=user_id) }}" title="{{ _('Edit') }}">
                 <i class="fa fa-wrench"></i>
@@ -74,4 +88,7 @@
       {% endfor %}
     </tbody>
   </table>
+
+
+
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ cssmin==0.2.0
 ckanext-saml2auth==1.2.3
 python-dotenv==1.0.0
 python-jose==3.3.0
+pandas==2.0.3


### PR DESCRIPTION
## Description
This PR improves the format of the org membership list edit page and adds a "download members' emails" button.

![image](https://github.com/fjelltopp/ckanext-unaids/assets/8988344/0fbde1b6-d45c-42a6-bca2-1d034c314e4e)


## Testing 
Testing suite included for the new blueprint. UI changes not tested. 

## Internationalisation and Localisation
Strings have been internationalist, but translations are still to be updated.

## Dependencies
Pandas has been added to handle the conversion of json/dicts to CSV. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
