### PR TITLE
ADX-1068 Extend dataset type validation exemption to harvester type.

### DIFF
--- a/ckanext/unaids/actions.py
+++ b/ckanext/unaids/actions.py
@@ -252,7 +252,7 @@ def user_list(original_action, context, data_dict):
 def package_create(next_action, context, data_dict):
     dataset_type = data_dict.get('type', '')
     valid_types = t.get_action("scheming_dataset_schema_list")(context, {})
-    valid_types = set(valid_types) | {'dataset'}
+    valid_types = set(valid_types) | {'dataset', 'harvest'}
     if dataset_type:
         if dataset_type not in valid_types:
             raise t.ValidationError(


### PR DESCRIPTION
## Description

A fix adding 'harvester' dataset type to whitelist for dataset type validation.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
