### PR TITLE
ADX-1046 Stop metadata changes triggering validation

### DIFF
--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -71,7 +71,6 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
     This plugin implements the configurations needed for AIDS data exchange
 
     """
-    resources_to_validate_package = {}
     p.implements(p.IClick)
     p.implements(p.IConfigurer)
     p.implements(p.IFacets, inherit=True)
@@ -188,33 +187,35 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
         if data_dict.get("schema"):
             return True
 
+    # IResourceController
+    # IPackageController
+    resources_to_validate_package = {}
+
     def after_create(self, context, pkg_dict):
-        if pkg_dict.get("validate_package") and not context.get("_dont_validate"):
+        if pkg_dict.get("validate_package"):
             toolkit.get_action("resource_validation_run_batch")(
                 context, {"dataset_ids": pkg_dict["package_id"]}
             )
 
-    # IPackageController
-    def after_update(self, context, pkg_dict):
-        if "extras" in pkg_dict:
+    def after_update(self, context, data_dict):
+        if "extras" in data_dict:
             org_to_allow_transfer_to = [
                 item["value"]
-                for item in pkg_dict["extras"]
+                for item in data_dict["extras"]
                 if item["key"] == "org_to_allow_transfer_to" and item["value"]
             ]
             if org_to_allow_transfer_to:
                 send_dataset_transfer_emails(
-                    dataset_id=pkg_dict["id"],
+                    dataset_id=data_dict["id"],
                     recipient_org_id=org_to_allow_transfer_to[0],
                 )
 
-        if pkg_dict['id'] in self.resources_to_validate_package and not context.get("_dont_validate"):
-            del self.resources_to_validate_package[pkg_dict['id']]
+        if data_dict['id'] in self.resources_to_validate_package:
+            del self.resources_to_validate_package[data_dict['id']]
             toolkit.get_action("resource_validation_run_batch")(
-                context, {"dataset_ids": pkg_dict["package_id"]}
+                context, {"dataset_ids": data_dict["package_id"]}
             )
 
-    # IResourceController
     def _process_schema_fields(self, data_dict):
         """
         Here we overload the default schema processing (from frictionlessdata/ckanext-validation)
@@ -238,16 +239,16 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
         return self._process_schema_fields(resource)
 
     def before_update(self, context, current, resource):
-        file_uploaded = current.get("url") != resource.get("url")
-
-        if file_uploaded and resource.get("validate_package"):
-            self.resources_to_validate_package[resource['id']] = True
-
         if _data_dict_is_resource(resource):
             _giftless_upload(context, resource, current=current)
             _update_resource_last_modified_date(resource, current=current)
             logic.validate_resource_upload_fields(context, resource)
             context["_resource_create_call"] = True
+            file_uploaded = current.get("url") != resource.get("url")
+
+            if file_uploaded and resource.get("validate_package"):
+                self.resources_to_validate_package[resource['id']] = True
+
         return self._process_schema_fields(resource)
 
     def before_show(self, resource):

--- a/ckanext/unaids/plugin.py
+++ b/ckanext/unaids/plugin.py
@@ -190,7 +190,6 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
 
     def after_create(self, context, pkg_dict):
         if pkg_dict.get("validate_package") and not context.get("_dont_validate"):
-            logging.warning("VALIDATING ENTIRE PACKAGE")
             toolkit.get_action("resource_validation_run_batch")(
                 context, {"dataset_ids": pkg_dict["package_id"]}
             )
@@ -211,7 +210,6 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
 
         if pkg_dict['id'] in self.resources_to_validate_package and not context.get("_dont_validate"):
             del self.resources_to_validate_package[pkg_dict['id']]
-            logging.warning("VALIDATING ENTIRE PACKAGE")
             toolkit.get_action("resource_validation_run_batch")(
                 context, {"dataset_ids": pkg_dict["package_id"]}
             )
@@ -241,6 +239,7 @@ class UNAIDSPlugin(p.SingletonPlugin, DefaultTranslation):
 
     def before_update(self, context, current, resource):
         file_uploaded = current.get("url") != resource.get("url")
+
         if file_uploaded and resource.get("validate_package"):
             self.resources_to_validate_package[resource['id']] = True
 

--- a/ckanext/unaids/tests/test_scheming_schemas/validate_package.json
+++ b/ckanext/unaids/tests/test_scheming_schemas/validate_package.json
@@ -1,0 +1,42 @@
+{
+  "scheming_version": 1,
+  "dataset_type": "validate-package",
+  "about_url": "http://github.com/ckan/ckanext-scheming",
+  "dataset_fields": [
+    {
+      "field_name": "title",
+      "label": "Title",
+      "preset": "title",
+      "form_placeholder": "eg. Larry, Peter, Susan"
+    },
+    {
+      "field_name": "name",
+      "label": "URL",
+      "preset": "dataset_slug",
+      "form_placeholder": "eg. camel-no-5"
+    },
+    {
+      "field_name": "locked",
+      "preset": "locked"
+    }
+  ],
+  "resource_fields": [
+    {
+      "field_name": "url",
+      "label": "Photo",
+      "preset": "resource_url_upload",
+      "form_placeholder": "http://example.com/my-camel-photo.jpg",
+      "upload_label": "Photo"
+    },
+    {
+      "field_name": "schema",
+      "preset": "hidden_value",
+      "field_value": "test_schema"
+    },
+    {
+      "field_name": "validate_package",
+      "preset": "hidden_value",
+      "field_value": "true"
+    }
+  ]
+}

--- a/ckanext/unaids/theme/templates/scheming/package/snippets/resource_form.html
+++ b/ckanext/unaids/theme/templates/scheming/package/snippets/resource_form.html
@@ -1,0 +1,15 @@
+{% ckan_extends %}
+
+{% block basic_fields %}
+
+{{ super() }}
+
+{% if data.get('validation_timestamp') %}
+   <input type="hidden" name="validation_timestamp" value="{{data.validation_timestamp}}" />
+{% endif %}
+
+{% if data.get('validation_status') %}
+   <input type="hidden" name="validation_status" value="{{data.validation_status}}" />
+{% endif %}
+
+{% endblock %}

--- a/test.ini
+++ b/test.ini
@@ -11,10 +11,11 @@ port = 5000
 [app:main]
 use = config:../ckan/test-core.ini
 ckan.resource_formats = %(here)s/ckanext/unaids/resource_formats.json
-ckanext.unaids.schema_directory = /ckanext/unaids/tests/test_schemas
+ckanext.unaids.schema_directory = %(here)s/ckanext/unaids/tests/test_schemas
 scheming.presets = ckanext.unaids:presets.json
                    ckanext.scheming:presets.json
 scheming.dataset_schemas = ckanext.unaids.tests.test_scheming_schemas:test_schema.json
+                           ckanext.unaids.tests.test_scheming_schemas:validate_package.json
 ckanext.authz_service.jwt_algorithm=none
 ckanext.authz_service.jwt_private_key=
 ckanext.blob_storage.storage_service_url=none


### PR DESCRIPTION
## Description

This PR employs exactly the same technique/approach used in ckanext-validation to check whether a resource_update request is updating the actual file or just the metadata., and then to trigger validation appropriately. Here we are just triggering the "validate whole package" action. 

Whether or not a resource_update request includes an update to the underlying file cannot be easily checked in the after_update hook, so we have to check before_update, keep a record of which resources are having their file updated, and then trigger validation accordingly from that record in the after_update hook. This is how ckanext-validation does it. 

The result is that a metadata change to the geo-data does not trigger validation of the whole package. 

A template change is also included to ensure that metadata persists across updates made through the UI. 

## Testing

Regression test included as well as a test to check the validate_packge metadata element works. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
