### PR TITLE
ADX-1087 Add Zanzibar (autonomous island in Tanzania) as location opt…

### DIFF
--- a/ckanext/unaids/blueprints/svg_map_options.py
+++ b/ckanext/unaids/blueprints/svg_map_options.py
@@ -29,9 +29,13 @@ def map_options():
     values = defaultdict(dataset_count)
     for geo_location, count in six.iteritems(location_facet):
         if geo_location:
-            country_code = _country_code_from_location_name(geo_location)
-            values[country_code]["count"] = count
-            values[country_code]["link"] = u'/dataset/?geo-location={}'.format(geo_location)
+            try:
+                country_code = _country_code_from_location_name(geo_location)
+                values[country_code]["count"] = count
+                values[country_code]["link"] = u'/dataset/?geo-location={}'.format(geo_location)
+            except AttributeError:
+                # custom location not supported by pycountry
+                continue
 
     return jsonify({
         "data": {


### PR DESCRIPTION
## Description
Add Zanzibar (autonomous island in Tanzania) as location option for datasets metadata. This required a custom handling of this "dummy" country in the SVG map location blueprint for the map on the ADR homepage.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
