### PR TITLE
ADX-1088 Extract frictionless js into separate webassets component.

### DIFF
--- a/ckanext/unaids/assets/webassets.yml
+++ b/ckanext/unaids/assets/webassets.yml
@@ -20,11 +20,19 @@ FileInputComponentStyles:
     filters: cssmin
     output: unaids/%(version)s_FileInputComponent.css
 
+FrictionlessJS:
+  filters: rjsmin
+  contents:
+    - frictionless-js.js
+  output: unaids/%(version)s_Frictionless.js
+
 FileInputComponentScripts:
     filters: rjsmin
     contents:
-        - frictionless-js.js
         - build/FileInputComponent.js
+    extra:
+      preload:
+        - ckanext-unaids/FrictionlessJS
     output: unaids/%(version)s_FileInputComponent.js
 
 BulkFileUploaderComponentStyles:
@@ -36,8 +44,10 @@ BulkFileUploaderComponentStyles:
 BulkFileUploaderComponentScripts:
     filters: rjsmin
     contents:
-        - frictionless-js.js
         - build/BulkFileUploaderComponent.js
+    extra:
+      preload:
+        - ckanext-unaids/FrictionlessJS
     output: unaids/%(version)s_BulkFileUploaderComponent.js
 
 MapSelectorJS:


### PR DESCRIPTION
## Description

Frictionless js file is a common library for FileUploader and BulkUploader components. I've extracted it as a separate common module in webassets.yml to improve use of cache during page download.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
