### PR TITLE
chore: Change default created dataset in dropdown menu to 2026 country estimates

### DIFF
--- a/ckanext/unaids/i18n/fr/LC_MESSAGES/ckanext-unaids.po
+++ b/ckanext/unaids/i18n/fr/LC_MESSAGES/ckanext-unaids.po
@@ -822,8 +822,8 @@ msgstr ""
 "href=\"http://fjelltopp.org\"><strong>Fjelltopp</strong></a>."
 
 #: ckanext/unaids/theme/templates/header.html:21
-msgid "2024 Instructions"
-msgstr "2024 Instructions"
+msgid "2026 Instructions"
+msgstr "2026 Instructions"
 
 #: ckanext/unaids/theme/templates/home/layout1.html:9
 msgid ""

--- a/ckanext/unaids/i18n/fr/LC_MESSAGES/ckanext-unaids.po
+++ b/ckanext/unaids/i18n/fr/LC_MESSAGES/ckanext-unaids.po
@@ -859,8 +859,8 @@ msgid "HIV Estimates<br />Navigator"
 msgstr "Navigateur<br />pour les Estimations du VIH"
 
 #: ckanext/unaids/theme/templates/home/layout1.html:41
-msgid "Instructions to upload your<br />Country Estimates 2025 Data"
-msgstr "Instructions pour mettre en ligne vos<br />données sur les estimations 2025"
+msgid "Instructions to upload your<br />Country Estimates 2026 Data"
+msgstr "Instructions pour mettre en ligne vos<br />données sur les estimations 2026"
 
 #: ckanext/unaids/theme/templates/home/layout1.html:45
 msgid "Unsure what to do next?"

--- a/ckanext/unaids/i18n/pt_PT/LC_MESSAGES/ckanext-unaids.po
+++ b/ckanext/unaids/i18n/pt_PT/LC_MESSAGES/ckanext-unaids.po
@@ -848,8 +848,8 @@ msgid "HIV Estimates<br />Navigator"
 msgstr "Navegador<br />de estimativas sobre o VIH"
 
 #: ckanext/unaids/theme/templates/home/layout1.html:41
-msgid "Instructions to upload your<br />Country Estimates 2025 Data"
-msgstr "Instruções para carregar os seus<br>dados de Estimativas do país 2025"
+msgid "Instructions to upload your<br />Country Estimates 2026 Data"
+msgstr "Instruções para carregar os seus<br>dados de Estimativas do país 2026"
 
 #: ckanext/unaids/theme/templates/home/layout1.html:45
 msgid "Unsure what to do next?"

--- a/ckanext/unaids/i18n/pt_PT/LC_MESSAGES/ckanext-unaids.po
+++ b/ckanext/unaids/i18n/pt_PT/LC_MESSAGES/ckanext-unaids.po
@@ -811,8 +811,8 @@ msgstr ""
 "href=\"http://fjelltopp.org\"><strong>Fjelltopp</strong></a>."
 
 #: ckanext/unaids/theme/templates/header.html:21
-msgid "2024 Instructions"
-msgstr "2024 Instruções"
+msgid "2026 Instructions"
+msgstr "2026 Instruções"
 
 #: ckanext/unaids/theme/templates/home/layout1.html:9
 msgid ""

--- a/ckanext/unaids/theme/templates/header.html
+++ b/ckanext/unaids/theme/templates/header.html
@@ -18,7 +18,7 @@
     {{ super() }}
     <li>
         <a  href="{{h.get_localized_page_url('inputs-unaids')}}">
-            {{_('2024 Instructions')}}
+            {{_('2026 Instructions')}}
         </a>
     </li>
 

--- a/ckanext/unaids/theme/templates/home/layout1.html
+++ b/ckanext/unaids/theme/templates/home/layout1.html
@@ -38,7 +38,7 @@
          href="{{ h.get_localized_page_url('inputs-unaids') }}"
          target="_blank">
         <i class="fa fa-info-circle"></i>
-        <span class="button-text">{{_('Instructions to upload your<br />Country Estimates 2025 Data')}}</span>
+        <span class="button-text">{{_('Instructions to upload your<br />Country Estimates 2026 Data')}}</span>
       </a>
       </div>
       <div class="hidden-xs hidden-sm col-md-6 col-lg-4 whats-next">

--- a/ckanext/unaids/theme/templates/snippets/dataset_selector.html
+++ b/ckanext/unaids/theme/templates/snippets/dataset_selector.html
@@ -3,7 +3,7 @@
     <i class="fa fa-plus-square"></i> {{_('Add Dataset')}}
   </button>
   <div class="dropdown-menu" aria-labelledby="addDatasetMenuButton">
-    {% snippet 'snippets/add_dataset.html', dataset_type='country-estimates-25' %}
+    {% snippet 'snippets/add_dataset.html', dataset_type='country-estimates-26' %}
     {% snippet 'snippets/add_dataset.html', dataset_type='dataset-2' %}
   </div>
 </div>


### PR DESCRIPTION
## Description

This PR changes the default dataset created from the dataset selector to 2026 dataset. I've not been able to test this yet. This is based on Tomek's PR from 2025 https://github.com/fjelltopp/ckanext-unaids/pull/320

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The GitHub ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
