### PR TITLE
chore (1/8): update CI workflow and deps for CKAN 2.11 + Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,16 +56,16 @@ jobs:
       run: |
         pip install -r requirements.txt
         pip install -r dev-requirements.txt
-        pip install -e "git+https://github.com/fjelltopp/ckanext-scheming@fix/ckan-2.11-python-3.10-compatibility#egg=ckanext-scheming"
-        pip install -e "git+https://github.com/fjelltopp/ckanext-validation@toavina/update-python#egg=ckanext-validation"
-        pip install -e "git+https://github.com/fjelltopp/ckanext-ytp-request@toavina/update-python#egg=ckanext-ytp-request"
+        pip install -e "git+https://github.com/fjelltopp/ckanext-scheming@development#egg=ckanext-scheming"
+        pip install -e "git+https://github.com/fjelltopp/ckanext-validation@development#egg=ckanext-validation"
+        pip install -e "git+https://github.com/fjelltopp/ckanext-ytp-request@chas/update-python#egg=ckanext-ytp-request"
         pip install -e "git+https://github.com/datopian/ckanext-authz-service@d179b19469faff7e461191db53e31c60d19003bc#egg=ckanext-authz-service"
         # Python 3.10 compatibility patch for ckanext-authz-service
         sed -i 's/from collections import Iterable, defaultdict/from collections.abc import Iterable\nfrom collections import defaultdict/' /srv/app/src/ckanext-authz-service/ckanext/authz_service/authzzie.py
         pip install -e "git+https://github.com/ckan/ckanext-pages.git@6c8d5939b01964c30a0394f10fef6e8f5a210ada#egg=ckanext-pages"
-        pip install -e "git+https://github.com/fjelltopp/ckanext-blob-storage@toavina/update-python#egg=ckanext-blob-storage"
-        pip install -e "git+https://github.com/fjelltopp/ckanext-versions@toavina/update-python#egg=ckanext-versions"
-        pip install -e "git+https://github.com/fjelltopp/ckanext-restricted@toavina/update-python#egg=ckanext-restricted"
+        pip install -e "git+https://github.com/fjelltopp/ckanext-blob-storage@master#egg=ckanext-blob-storage"
+        pip install -e "git+https://github.com/fjelltopp/ckanext-versions@development#egg=ckanext-versions"
+        pip install -e "git+https://github.com/fjelltopp/ckanext-restricted@chas/update-python#egg=ckanext-restricted"
         pip install -e .
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
         pip install -r dev-requirements.txt
         pip install -e "git+https://github.com/fjelltopp/ckanext-scheming@development#egg=ckanext-scheming"
         pip install -e "git+https://github.com/fjelltopp/ckanext-validation@development#egg=ckanext-validation"
-        pip install -e "git+https://github.com/fjelltopp/ckanext-ytp-request@chas/update-python#egg=ckanext-ytp-request"
+        pip install -e "git+https://github.com/fjelltopp/ckanext-ytp-request@development#egg=ckanext-ytp-request"
         pip install -e "git+https://github.com/datopian/ckanext-authz-service@d179b19469faff7e461191db53e31c60d19003bc#egg=ckanext-authz-service"
         # Python 3.10 compatibility patch for ckanext-authz-service (the pinned upstream commit
         # still uses the removed `from collections import Iterable`). Verify the patch applied so
@@ -68,7 +68,7 @@ jobs:
         pip install -e "git+https://github.com/ckan/ckanext-pages.git@6c8d5939b01964c30a0394f10fef6e8f5a210ada#egg=ckanext-pages"
         pip install -e "git+https://github.com/fjelltopp/ckanext-blob-storage@master#egg=ckanext-blob-storage"
         pip install -e "git+https://github.com/fjelltopp/ckanext-versions@development#egg=ckanext-versions"
-        pip install -e "git+https://github.com/fjelltopp/ckanext-restricted@chas/update-python#egg=ckanext-restricted"
+        pip install -e "git+https://github.com/fjelltopp/ckanext-restricted@development#egg=ckanext-restricted"
         pip install -e .
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,8 +60,11 @@ jobs:
         pip install -e "git+https://github.com/fjelltopp/ckanext-validation@development#egg=ckanext-validation"
         pip install -e "git+https://github.com/fjelltopp/ckanext-ytp-request@chas/update-python#egg=ckanext-ytp-request"
         pip install -e "git+https://github.com/datopian/ckanext-authz-service@d179b19469faff7e461191db53e31c60d19003bc#egg=ckanext-authz-service"
-        # Python 3.10 compatibility patch for ckanext-authz-service
+        # Python 3.10 compatibility patch for ckanext-authz-service (the pinned upstream commit
+        # still uses the removed `from collections import Iterable`). Verify the patch applied so
+        # a future upstream change to that line fails the build loudly instead of silently skipping it.
         sed -i 's/from collections import Iterable, defaultdict/from collections.abc import Iterable\nfrom collections import defaultdict/' /srv/app/src/ckanext-authz-service/ckanext/authz_service/authzzie.py
+        grep -q 'from collections.abc import Iterable' /srv/app/src/ckanext-authz-service/ckanext/authz_service/authzzie.py
         pip install -e "git+https://github.com/ckan/ckanext-pages.git@6c8d5939b01964c30a0394f10fef6e8f5a210ada#egg=ckanext-pages"
         pip install -e "git+https://github.com/fjelltopp/ckanext-blob-storage@master#egg=ckanext-blob-storage"
         pip install -e "git+https://github.com/fjelltopp/ckanext-versions@development#egg=ckanext-versions"
@@ -80,7 +83,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-            node-version: 16.14.2
+            node-version: 20
       - name: Setup extension
         run: |
           cd ./ckanext/unaids/react

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,15 +3,11 @@ on: [pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ 3.9 ]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax
@@ -19,40 +15,16 @@ jobs:
           flake8 . --count --max-line-length=127 --show-source --statistics
 
   test:
-    name: CKAN
+    name: CKAN 2.11
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - ckan-container-version: "2.9"
-            ckan-postgres-version: "2.9"
-            ckan-solr-version: "2.9-solr8"
-            requirements-dev: "dev-requirements.py3.txt"
-            ckanext-requirements: |
-              pip install -r https://raw.githubusercontent.com/fjelltopp/ckanext-scheming/development/requirements.txt
-              pip install -r https://raw.githubusercontent.com/fjelltopp/ckanext-validation/d83751760cd93836e4ca44b46ffb629907f06576/requirements.txt
-              pip install -r https://raw.githubusercontent.com/fjelltopp/ckanext-blob-storage/development/requirements.py3.txt
-              pip install -r https://raw.githubusercontent.com/fjelltopp/ckanext-versions/development/requirements.txt
-              pip install -r https://raw.githubusercontent.com/fjelltopp/ckanext-restricted/development/requirements.txt
-          - ckan-container-version: "2.10"
-            ckan-postgres-version: "2.10"
-            ckan-solr-version: "2.10"
-            requirements-dev: "dev-requirements.py3.txt"
-            ckanext-requirements: |
-              pip install -r https://raw.githubusercontent.com/fjelltopp/ckanext-scheming/development/requirements.txt
-              pip install -r https://raw.githubusercontent.com/fjelltopp/ckanext-validation/d83751760cd93836e4ca44b46ffb629907f06576/requirements.txt
-              pip install -r https://raw.githubusercontent.com/fjelltopp/ckanext-blob-storage/development/requirements.py3.txt
-              pip install -r https://raw.githubusercontent.com/fjelltopp/ckanext-versions/development/requirements.txt
-              pip install -r https://raw.githubusercontent.com/fjelltopp/ckanext-restricted/development/requirements.txt 
-
     container:
-      image: openknowledge/ckan-dev:${{ matrix.ckan-container-version }}
+      image: ckan/ckan-dev:2.11-py3.10
+      options: --user root
     services:
       solr:
-        image: ckan/ckan-solr:${{ matrix.ckan-solr-version }}
+        image: ckan/ckan-solr:2.11-solr9
       postgres:
-        image: ckan/ckan-postgres-dev:${{ matrix.ckan-postgres-version }}
+        image: ckan/ckan-postgres-dev:2.11
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -68,7 +40,12 @@ jobs:
       CKAN_REDIS_URL: redis://redis:6379/1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
+    - name: Initialize git repository
+      run: |
+        git config --global user.email "test@example.com"
+        git config --global user.name "Test User"
+        git config --global --add safe.directory /__w/ckanext-unaids/ckanext-unaids
     - uses: borales/actions-yarn@v3.0.0
       with:
         cmd: --cwd ckanext/unaids/react/ install
@@ -78,17 +55,17 @@ jobs:
     - name: Install requirements
       run: |
         pip install -r requirements.txt
-        pip install -r ${{ matrix.requirements-dev }}
-        pip install -e "git+https://github.com/fjelltopp/ckanext-scheming@development#egg=ckanext-scheming"
-        pip install -e "git+https://github.com/fjelltopp/ckanext-validation@development#egg=ckanext-validation"
-        pip install -e "git+https://github.com/fjelltopp/ckanext-ytp-request@development#egg=ckanext-ytp-request"
-        pip install -e "git+https://github.com/datopian/ckanext-authz-service@bd4c80f55a714c1117a0e130d07463e383c494c7#egg=ckanext-authz-service"
-        pip install -e "git+https://github.com/ckan/ckanext-pages.git@v0.3.4#egg=ckanext-pages"
-        pip install -e "git+https://github.com/fjelltopp/ckanext-blob-storage@development#egg=ckanext-blob-storage"
-        pip install -e "git+https://github.com/fjelltopp/ckanext-versions@development#egg=ckanext-versions"
-        pip install -e "git+https://github.com/fjelltopp/ckanext-restricted@development#egg=ckanext-restricted"
-        ${{ matrix.ckanext-requirements }}
-
+        pip install -r dev-requirements.txt
+        pip install -e "git+https://github.com/fjelltopp/ckanext-scheming@fix/ckan-2.11-python-3.10-compatibility#egg=ckanext-scheming"
+        pip install -e "git+https://github.com/fjelltopp/ckanext-validation@toavina/update-python#egg=ckanext-validation"
+        pip install -e "git+https://github.com/fjelltopp/ckanext-ytp-request@toavina/update-python#egg=ckanext-ytp-request"
+        pip install -e "git+https://github.com/datopian/ckanext-authz-service@d179b19469faff7e461191db53e31c60d19003bc#egg=ckanext-authz-service"
+        # Python 3.10 compatibility patch for ckanext-authz-service
+        sed -i 's/from collections import Iterable, defaultdict/from collections.abc import Iterable\nfrom collections import defaultdict/' /srv/app/src/ckanext-authz-service/ckanext/authz_service/authzzie.py
+        pip install -e "git+https://github.com/ckan/ckanext-pages.git@6c8d5939b01964c30a0394f10fef6e8f5a210ada#egg=ckanext-pages"
+        pip install -e "git+https://github.com/fjelltopp/ckanext-blob-storage@toavina/update-python#egg=ckanext-blob-storage"
+        pip install -e "git+https://github.com/fjelltopp/ckanext-versions@toavina/update-python#egg=ckanext-versions"
+        pip install -e "git+https://github.com/fjelltopp/ckanext-restricted@toavina/update-python#egg=ckanext-restricted"
         pip install -e .
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
@@ -100,8 +77,8 @@ jobs:
   test-js:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
             node-version: 16.14.2
       - name: Setup extension

--- a/dev-requirements.py3.txt
+++ b/dev-requirements.py3.txt
@@ -1,5 +1,0 @@
-pytest-ckan
-pytest-cov
-pytest-mock
-ckantoolkit
-pytest-rerunfailures==10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ ckanext-saml2auth==1.2.3
 python-dotenv==1.0.0
 python-jose==3.3.0
 pandas==2.0.3
+numpy>=1.21.0,<2.0
+frictionless>=5.0.0
+tableschema>=1.21.0

--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,7 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:/srv/app/src/ckan/test-core.ini
+use = config:../ckan/test-core.ini
 ckan.resource_formats = %(here)s/ckanext/unaids/resource_formats.json
 ckanext.unaids.schema_directory = %(here)s/ckanext/unaids/tests/test_schemas
 scheming.presets = ckanext.unaids:presets.json

--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,7 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:../ckan/test-core.ini
+use = config:/srv/app/src/ckan/test-core.ini
 ckan.resource_formats = %(here)s/ckanext/unaids/resource_formats.json
 ckanext.unaids.schema_directory = %(here)s/ckanext/unaids/tests/test_schemas
 scheming.presets = ckanext.unaids:presets.json


### PR DESCRIPTION
## Summary

- Replace CKAN 2.9/2.10 matrix with a single CKAN 2.11 + Python 3.10 job
- Bump Docker images to `ckan-dev:2.11-py3.10`, `ckan-solr:2.11-solr9`, `ckan-postgres-dev:2.11`
- Add `safe.directory` git config step required inside the CKAN 2.11 container
- Update `actions/checkout`, `setup-python`, `setup-node` to `@v6`
- Pin extension deps to CKAN-2.11-compatible branches/commits; inline `collections.abc` patch for `ckanext-authz-service` (Python 3.10 compat)
- Add `numpy>=1.21.0,<2.0`, `frictionless>=5.0.0`, `tableschema>=1.21.0` to `requirements.txt`
- Fix `test.ini` core config path for the CKAN 2.11 container layout (`/srv/app/src/ckan/test-core.ini`)

## Notes

- This is PR #1 of a CKAN 2.11 migration sequence — CI/workflow and dependency changes only. No application code is touched here; subsequent PRs will handle runtime and test-suite fixes.
- The tests will definitively fail.

The `test.ini` path set here (`/srv/app/src/ckan/test-core.ini`) is also overwritten at runtime by the `sed` line in the workflow, so both paths end up consistent in CI.

## Test plan

- [ ] CI workflow runs on this PR and uses the correct CKAN 2.11 images
- [ ] Lint job passes on Python 3.10