### PR TITLE
chore (3/8): align test suite with CKAN 2.11 plugin/route changes

### DIFF
--- a/ckanext/unaids/tests/conftest.py
+++ b/ckanext/unaids/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import ckan.plugins as p
 
 from ckan.tests import factories
 from ckanext.unaids.tests import unaids_db_setup, create_version
@@ -7,8 +8,19 @@ from ckanext.validation.model import tables_exist, create_tables
 from ckanext.ytp_request.tests import ytp_request_db_setup
 
 
+@pytest.fixture
+def clean_db_with_migrations(clean_db, with_plugins, migrate_db_for):
+    # CKAN 2.11: clean_db rebuilds the core schema only. Plugin-owned tables
+    # (activity.permission_labels as text[], ckanext_pages) need their Alembic
+    # migrations re-applied. Only migrate plugins actually loaded for this test
+    # so test classes don't need to declare plugins they don't use.
+    for plugin_name in ("activity", "pages"):
+        if p.plugin_loaded(plugin_name):
+            migrate_db_for(plugin_name)
+
+
 @pytest.fixture(autouse=True)
-def unaids_setup(clean_db):
+def unaids_setup(clean_db_with_migrations):
     if not tables_exist():
         create_tables()
 

--- a/ckanext/unaids/tests/test_actions.py
+++ b/ckanext/unaids/tests/test_actions.py
@@ -14,7 +14,7 @@ from ckanext.unaids.tests import get_context, create_dataset_with_releases
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids blob_storage scheming_datasets')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids blob_storage scheming_datasets')
 @pytest.mark.usefixtures('with_plugins')
 class TestGetTableSchema(object):
 
@@ -41,7 +41,7 @@ class TestGetTableSchema(object):
         assert response == {}
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids versions scheming_datasets')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids versions scheming_datasets')
 @pytest.mark.usefixtures('with_plugins')
 class TestPackageActivityList(object):
 
@@ -54,7 +54,7 @@ class TestPackageActivityList(object):
         pass
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids')
 @pytest.mark.usefixtures('with_plugins')
 class TestFormatGuess(object):
 
@@ -72,7 +72,7 @@ class TestFormatGuess(object):
         assert response.get('format') == format
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids')
 @pytest.mark.usefixtures('with_plugins')
 class TestUserShowMe(object):
 
@@ -87,7 +87,7 @@ class TestUserShowMe(object):
         assert response['name'] == user['name']
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids scheming_datasets')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids scheming_datasets')
 @pytest.mark.usefixtures('with_plugins')
 class TestPopulateDataDictionary(object):
 
@@ -105,7 +105,7 @@ class TestPopulateDataDictionary(object):
         mock_populate_data_dictionary_from_schema.assert_called_once_with(mocker.ANY, resource)
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids')
 @pytest.mark.usefixtures('with_plugins')
 class TestUserAffiliation(object):
     def test_user_show_with_affiliation(self):
@@ -156,7 +156,7 @@ class TestUserAffiliation(object):
         assert set(response) == {'test-user-0', 'test-user-1', 'test-user-2', 'test-user-3'}
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids scheming_datasets')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids scheming_datasets')
 @pytest.mark.usefixtures('with_plugins')
 class TestPackageCreate():
 

--- a/ckanext/unaids/tests/test_actions_dataset_lock.py
+++ b/ckanext/unaids/tests/test_actions_dataset_lock.py
@@ -16,7 +16,7 @@ def locked_dataset():
     return locked_dataset
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids scheming_datasets versions')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids scheming_datasets versions')
 @pytest.mark.usefixtures('with_plugins')
 class TestDatasetLock(object):
     def test_metadata_updated(self, locked_dataset):
@@ -43,7 +43,7 @@ class TestDatasetLock(object):
         assert not dataset["locked"], "Dataset shouldn't be locked if release not created"
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids scheming_datasets versions')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids scheming_datasets versions')
 @pytest.mark.usefixtures('with_plugins')
 class TestDatasetUnlock(object):
     def test_metadata_updated(self, locked_dataset):

--- a/ckanext/unaids/tests/test_actions_show_for_release.py
+++ b/ckanext/unaids/tests/test_actions_show_for_release.py
@@ -6,7 +6,7 @@ from ckan.plugins import toolkit
 
 @pytest.mark.ckan_config(
     'ckan.plugins',
-    'ytp_request unaids versions restricted blob_storage scheming_datasets'
+    'activity ytp_request unaids versions restricted blob_storage scheming_datasets'
 )
 @pytest.mark.usefixtures('with_plugins')
 class TestDatasetShowForRelease(object):

--- a/ckanext/unaids/tests/test_auth.py
+++ b/ckanext/unaids/tests/test_auth.py
@@ -15,7 +15,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids scheming_datasets versions')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids scheming_datasets versions')
 @pytest.mark.usefixtures('with_plugins')
 class TestAuth(object):
 

--- a/ckanext/unaids/tests/test_auth_logic.py
+++ b/ckanext/unaids/tests/test_auth_logic.py
@@ -35,7 +35,7 @@ class TestExtractToken(object):
             auth_logic.extract_token("Bearer")
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids')
 @pytest.mark.usefixtures('with_plugins')
 class TestVerifyRequiredScope(object):
 
@@ -57,7 +57,7 @@ class TestVerifyRequiredScope(object):
             auth_logic.verify_required_scope(token)
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids')
 @pytest.mark.usefixtures('with_request_context', 'with_plugins')
 class TestAccessTokenPresentAndValidAndUserAuthorized():
 
@@ -144,7 +144,7 @@ class TestCreateResponse:
         assert response.content_type == "text/json"
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids')
 @pytest.mark.usefixtures('with_request_context', 'with_plugins')
 class TestValidateAndDecodeToken(object):
     @patch('ckanext.unaids.auth_logic.jwt.decode')
@@ -297,7 +297,7 @@ class TestValidateAndDecodeToken(object):
             auth_logic.validate_and_decode_token(encoded)
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids scheming_datasets')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids scheming_datasets')
 @pytest.mark.usefixtures('with_request_context', 'with_plugins', 'clean_db')
 class TestRegressionOAuth2PluginDoesntPreventVanillaCkanAuthentication:
 

--- a/ckanext/unaids/tests/test_blueprints.py
+++ b/ckanext/unaids/tests/test_blueprints.py
@@ -9,7 +9,7 @@ from io import StringIO
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids pages')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids pages')
 @pytest.mark.usefixtures('with_plugins')
 class TestValidateUserProfileBlueprint(object):
     def test_annonymous_access_to_index_page(self, app):
@@ -27,7 +27,7 @@ def test_org_download(app, test_organization):
     return app.get(url, extra_environ={'REMOTE_USER': org_admin_username})
 
 
-@pytest.mark.ckan_config("ckan.plugins", "ytp_request unaids pages")
+@pytest.mark.ckan_config("ckan.plugins", "activity ytp_request unaids pages")
 @pytest.mark.usefixtures("with_plugins")
 class TestMemberLists(object):
     def test_org_member_download_200_ok(self, test_org_download):

--- a/ckanext/unaids/tests/test_dataset_releases.py
+++ b/ckanext/unaids/tests/test_dataset_releases.py
@@ -53,7 +53,7 @@ def assert_releases_are_exactly(user, dataset_id, expected_releases):
 
 
 @pytest.mark.usefixtures('with_plugins')
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids blob_storage versions pages scheming_datasets')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids blob_storage versions pages scheming_datasets')
 class TestDatasetReleaseCreateAndEdit(object):
 
     def _create_or_edit(self, app, user, dataset, release, activity_id=None):
@@ -149,7 +149,7 @@ class TestDatasetReleaseCreateAndEdit(object):
 
 
 @pytest.mark.usefixtures('with_plugins')
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids blob_storage versions pages scheming_datasets')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids blob_storage versions pages scheming_datasets')
 class TestDatasetReleaseDelete(object):
 
     def _delete(self, app, user, dataset, release):
@@ -190,7 +190,7 @@ class TestDatasetReleaseDelete(object):
 
 
 @pytest.mark.usefixtures('with_plugins')
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids blob_storage versions pages scheming_datasets')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids blob_storage versions pages scheming_datasets')
 class TestDatasetReleaseRestore(object):
 
     def _restore(self, app, user, dataset, release):
@@ -234,7 +234,7 @@ class TestDatasetReleaseRestore(object):
 
 
 @pytest.mark.usefixtures('with_plugins')
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids blob_storage versions pages scheming_datasets')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids blob_storage versions pages scheming_datasets')
 class TestDatasetReleaseListView(object):
 
     def test_no_releases_created(self, app):
@@ -272,7 +272,7 @@ class TestDatasetReleaseListView(object):
 
 
 @pytest.mark.usefixtures('with_plugins')
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids blob_storage versions pages scheming_datasets')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids blob_storage versions pages scheming_datasets')
 class TestDatasetRead(object):
 
     def _get_dataset_release_sidebar(self, app, user, dataset, activity_id=None):

--- a/ckanext/unaids/tests/test_dataset_transfer.py
+++ b/ckanext/unaids/tests/test_dataset_transfer.py
@@ -12,7 +12,7 @@ from ckanext.unaids.dataset_transfer.logic import (
 
 
 @pytest.mark.ckan_config('ckan.auth.allow_dataset_collaborators', True)
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids scheming_datasets versions blob_storage pages')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids scheming_datasets versions blob_storage pages')
 @pytest.mark.usefixtures('with_plugins')
 class TestDatasetTransfer(object):
 

--- a/ckanext/unaids/tests/test_giftless_backend.py
+++ b/ckanext/unaids/tests/test_giftless_backend.py
@@ -10,7 +10,7 @@ from werkzeug.datastructures import FileStorage as FlaskFileStorage
 import ckan.lib.helpers as h
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids authz_service blob_storage')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids authz_service blob_storage')
 @pytest.mark.usefixtures('with_plugins')
 class TestGiftlessBackend(object):
 
@@ -51,7 +51,7 @@ class TestGiftlessBackend(object):
         assert resource.get('name', None) == filename
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids pages blob_storage scheming_datasets')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids pages blob_storage scheming_datasets')
 class TestResourceUrlEncoding():
     def test_resource_url_encoding_test(self, app):
         user = factories.User()

--- a/ckanext/unaids/tests/test_helpers.py
+++ b/ckanext/unaids/tests/test_helpers.py
@@ -3,7 +3,7 @@ from ckan.tests import factories
 from ckan.plugins import toolkit
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'unaids scheming_datasets versions')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids scheming_datasets versions')
 @pytest.mark.usefixtures('with_plugins')
 class TestDatasetLockHelper(object):
     def test_dataset_lockable(self):

--- a/ckanext/unaids/tests/test_logic.py
+++ b/ckanext/unaids/tests/test_logic.py
@@ -6,7 +6,7 @@ from ckan.tests import factories
 from ckanext.unaids import logic
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids authz_service blob_storage')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids authz_service blob_storage')
 @pytest.mark.usefixtures('with_plugins')
 @pytest.mark.parametrize(
     "lfs_prefix,sha256,size,valid",
@@ -52,7 +52,7 @@ def test_validate_resource_upload_fields(lfs_prefix, sha256, size, valid):
         logic.validate_resource_upload_fields(context, resource_dict)
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids authz_service blob_storage scheming_datasets')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids authz_service blob_storage scheming_datasets')
 @pytest.mark.usefixtures('with_plugins')
 def test_update_filename_in_upload_resource_url():
     actual_filename = u"TeStè.CSV"
@@ -66,7 +66,7 @@ def test_update_filename_in_upload_resource_url():
     assert resource['url'].endswith(expected_filename)
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids authz_service blob_storage scheming_datasets')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids authz_service blob_storage scheming_datasets')
 @pytest.mark.usefixtures('with_plugins')
 @pytest.mark.parametrize("link_url",
                          ["http://link.my", "https://link.my", "https://link.my/path/to/resource"],

--- a/ckanext/unaids/tests/test_plugin.py
+++ b/ckanext/unaids/tests/test_plugin.py
@@ -67,7 +67,7 @@ def resource_with_link_and_updated_metadata():
     return updated_resource
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids blob_storage scheming_datasets')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids blob_storage scheming_datasets')
 @pytest.mark.usefixtures('with_plugins')
 class TestPlugin(object):
     '''Tests for the ckanext.example_iauthfunctions.plugin module.
@@ -117,7 +117,7 @@ def validate_package_resource():
     return resource
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids blob_storage authz_service validation scheming_datasets')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids blob_storage authz_service validation scheming_datasets')
 @pytest.mark.usefixtures('with_plugins')
 class TestValidatePackage(object):
 

--- a/ckanext/unaids/tests/test_validators.py
+++ b/ckanext/unaids/tests/test_validators.py
@@ -25,7 +25,7 @@ def read_only_validator():
     return read_only(read_only_field, test_schema)
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'ytp_request unaids scheming_datasets')
+@pytest.mark.ckan_config('ckan.plugins', 'activity ytp_request unaids scheming_datasets')
 @pytest.mark.usefixtures('with_plugins')
 class TestValidators(object):
 

--- a/ckanext/unaids/theme/templates/package/read_base.html
+++ b/ckanext/unaids/theme/templates/package/read_base.html
@@ -32,7 +32,7 @@
 {% set dataset_id = pkg.id if is_activity_archive else pkg.name %}
 {{ h.build_nav_icon(dataset_type ~ '.read', _('Dataset'), id=dataset_id,
 icon='sitemap') }}
-{{ h.build_nav_icon(dataset_type ~ '.activity', _('Activity Stream'), id=dataset_id,
+{{ h.build_nav_icon('activity.package_activity', _('Activity Stream'), id=dataset_id,
 icon='clock-o') }}
 {{ h.build_nav_icon('unaids_dataset_releases.list_releases', _('Releases'), dataset_type=dataset_type, dataset_id=dataset_id, icon='code-fork') }}
 {% endblock %}
@@ -46,7 +46,7 @@ icon='clock-o') }}
     <span> {{ _('Release') }}</span>
   </h2>
   <div class="module-content">
-  {% set release = h.get_current_dataset_release(dataset_id, request.args.activity_id) %}
+  {% set release = h.get_current_dataset_release(dataset_id, request.view_args.activity_id) %}
   {% if release %}
     <h2 style="margin: 0;"><b>{{ release.name }}</b></h2>
     <p class="text-muted">

--- a/ckanext/unaids/theme/templates/package/releases/list.html
+++ b/ckanext/unaids/theme/templates/package/releases/list.html
@@ -4,11 +4,11 @@
 
 {% set urls = {
     'create_from_latest_version': h.url_for('unaids_dataset_releases.release_view', dataset_type=dataset_type, dataset_id=pkg.name),
-    'create_from_an_older_version': h.url_for('dataset.activity', id=pkg.id, create_release=True)
+    'create_from_an_older_version': h.url_for('activity.package_activity', id=pkg.id, create_release=True)
 } %}
 
 {% if h.check_access('version_create', {'package_id': pkg.id}) %}
-    {% set release = h.get_current_dataset_release(pkg.id, request.args.activity_id) %}
+    {% set release = h.get_current_dataset_release(pkg.id, request.view_args.activity_id) %}
     {% if release %}
         <p class="empty">
             <span>{{ _('The current version of the dataset is already used by release') }} {{ release.name }},</span>


### PR DESCRIPTION
## Summary

**Single cause: making the test suite run under CKAN 2.11.** Three structural changes, each tied to a concrete 2.11 change — no test logic was rewritten here (the per-test body fixes are split into #327). Two templates are touched; both are activity-plugin route renames (same cause as #330), needed because the tests render those pages.

This PR is the "make the suite executable" layer; #327 then fixes the individual test bodies. Split this way per the client's request to keep each PR to a single concern.

## Changes (by cause)

### 1. `conftest.py` — `clean_db_with_migrations` fixture *(cause: 2.11 `clean_db` rebuilds core schema only)*
A 7-line fixture calling CKAN's own `migrate_db_for("activity")` and `migrate_db_for("pages")` to re-apply the upstream Alembic migrations `clean_db` doesn't include in 2.11:
- activity's `permission_labels text[]` column (activity is decoupled into a plugin in 2.11)
- `ckanext-pages` tables (third-party plugin)

It no-ops for tests that don't load each plugin. **This deliberately replaces the source branch's raw `ALTER TABLE` / `CREATE TABLE` SQL with CKAN's canonical `migrate_db_for` pattern** — directly addressing the earlier review note about hand-written SQL. **Required:** without it, tests touching activity/pages fail on missing column/tables.

### 2. Per-test-class `ckan.plugins` markers *(cause: activity decoupled to a plugin in 2.11)*
Prepend `activity` to every `ckan_config('ckan.plugins', ...)` marker that lists `unaids`; add `ytp_request` to `test_helpers.py`. Our `unaids` plugin chains `package_activity_list`, which fails to register unless `activity` is loaded first (and `member_request_create` needs `ytp_request`). **Required:** without it, loading `unaids` in those tests raises "action not found for chained action."

### 3. Two template route renames *(cause: activity-plugin route renames in 2.11 — same as #330)*
`package/read_base.html`, `package/releases/list.html`:
- `'dataset.activity'` → `'activity.package_activity'` (endpoint moved into the activity blueprint)
- `request.args.activity_id` → `request.view_args.activity_id` (2.11 moved activity_id from query string to a URL-path variable — verified working)

**Required:** these pages are rendered by the suite; the old route 404s under 2.11.

## Required?

Yes — every change maps to a specific 2.11 behaviour change (schema-rebuild scope, activity-as-plugin, activity-route renames). Nothing cosmetic or speculative.

## Test progression

| Stage | Passed | Failed | Errors |
|---|---|---|---|
| After #325 | 24 | 3 | 134 |
| After this PR (#326) | 148 | 11 | 2 |
| After #327 (per-test bodies) | **160** | 0 | 0 |

The 11 remaining failures after this PR are the per-test-body issues, fixed in **#327** (not pending follow-up — that PR is already open and green).

## Stacking note

Targets `chore/ckan-211-pr2-runtime-fixes` (#325). Merge order: #324 → #325 → this → #327 → #328 → #329 → #330.

## Test plan

- [x] Full suite green at the top of the stack (160 passed / 1 skipped)
- [ ] CI green on this branch