### PR TITLE
chore (5/8): migrate templates from Bootstrap 3 to Bootstrap 5

### DIFF
--- a/ckanext/unaids/assets/css/ckanext-geoview.css
+++ b/ckanext/unaids/assets/css/ckanext-geoview.css
@@ -1,6 +1,8 @@
-.label[data-format=shp]{
+.label[data-format=shp],
+.badge[data-format=shp]{
     background-color: #91318c;
 }
-.label[data-format=geojson] {
+.label[data-format=geojson],
+.badge[data-format=geojson] {
     background-color: #8d2932;
 }

--- a/ckanext/unaids/assets/custom.css
+++ b/ckanext/unaids/assets/custom.css
@@ -134,45 +134,67 @@ a.dropdown-item{
 }
 
 .label[data-format=html],
-.label[data-format*=html] {
+.badge[data-format=html],
+.label[data-format*=html],
+.badge[data-format*=html] {
   background-color: #55a1ce;
 }
-.label[data-format=json]{
+.label[data-format=json],
+.badge[data-format=json]{
   background-color: #ef7100;
 }
 .label[data-format=xml],
-.label[data-format*=xml] {
+.badge[data-format=xml],
+.label[data-format*=xml],
+.badge[data-format*=xml] {
   background-color: #ef7100;
 }
 .label[data-format=text],
-.label[data-format*=text] {
+.badge[data-format=text],
+.label[data-format*=text],
+.badge[data-format*=text] {
   background-color: #74cbec;
 }
 .label[data-format=csv],
-.label[data-format*=csv] {
+.badge[data-format=csv],
+.label[data-format*=csv],
+.badge[data-format*=csv] {
   background-color: #dfb100;
 }
 .label[data-format=xls],
-.label[data-format*=xls] {
+.badge[data-format=xls],
+.label[data-format*=xls],
+.badge[data-format*=xls] {
   background-color: #2db55d;
 }
 .label[data-format=zip],
-.label[data-format*=zip] {
+.badge[data-format=zip],
+.label[data-format*=zip],
+.badge[data-format*=zip] {
   background-color: #686868;
 }
 .label[data-format=api],
-.label[data-format*=api] {
+.badge[data-format=api],
+.label[data-format*=api],
+.badge[data-format*=api] {
   background-color: #ec96be;
 }
 .label[data-format=pdf],
-.label[data-format*=pdf] {
+.badge[data-format=pdf],
+.label[data-format*=pdf],
+.badge[data-format*=pdf] {
   background-color: #e0051e;
 }
 .label[data-format=rdf],
+.badge[data-format=rdf],
 .label[data-format*=rdf],
+.badge[data-format*=rdf],
 .label[data-format*=nquad],
+.badge[data-format*=nquad],
 .label[data-format*=ntriples],
-.label[data-format*=turtle] {
+.badge[data-format*=ntriples],
+.label[data-format*=turtle],
+.badge[data-format*=turtle] {
   background-color: #0b4498;
 }
 

--- a/ckanext/unaids/assets/download_all.js
+++ b/ckanext/unaids/assets/download_all.js
@@ -11,10 +11,10 @@ this.ckan.module('download_all', function ($) {
     initialize: function () {
       $.proxyAll(this, /_on/);
       if(this.options.files.length > 1){
-        $(this.el).removeClass('hidden');
+        $(this.el).removeClass('d-none');
         this.el.on('click', this._onClick);
       }else{
-        $(this.el).addClass('hidden');
+        $(this.el).addClass('d-none');
       }
     },
     _onClick: function (event) {

--- a/ckanext/unaids/theme/templates/home/index.html
+++ b/ckanext/unaids/theme/templates/home/index.html
@@ -1,0 +1,17 @@
+{% extends "page.html" %}
+
+{% block subtitle %}{{ _("Welcome") }}{% endblock %}
+
+{% block maintag %}{% endblock %}
+{% block toolbar %}{% endblock %}
+
+{% block content %}
+<div class="homepage">
+  <div id="content" class="container">
+    {{ self.flash() }}
+  </div>
+  {% block primary_content %}
+  {% include "home/layout1.html" %}
+  {% endblock %}
+</div>
+{% endblock %}

--- a/ckanext/unaids/theme/templates/home/layout1.html
+++ b/ckanext/unaids/theme/templates/home/layout1.html
@@ -8,7 +8,7 @@
             <div id="unaids-wordcloud" class="text-center">
               {{_('<span style="font-size: 2em; color: grey;">The AIDS Data Repository<br />aims to improve the</span><br /><span style="font-size: 2.75em; font-weight: bold;">quality, accessibility <br /> and consistency</span><span style="font-size: 2em;"> of HIV data<br />and HIV estimates by </span><span style="font-size: 2em; color: grey;">providing a</span><br /><span style="font-size: 2.5em; font-weight: bold;">centralised platform</span><br /><span style="font-size: 2em;">with tools to help countries </span><span style="font-size: 2em; font-weight: bold;">manage<br />and share </span><span style="font-size: 2em; color: grey;">their HIV data.</span>')}}
             </div>
-            <a class="pull-right" href={{h.url_for("/pages/about")}}>
+            <a class="float-end" href={{h.url_for("/pages/about")}}>
               {{_('Find out more...')}}
             </a>
           </section>
@@ -27,7 +27,7 @@
 <div role="main" class="help-panel">
   <div class="container">
     <div class='row'>
-      <div class="col-xs-12 order-xs-2 col-md-6 col-lg-4 col-lg-offset-2">
+      <div class="col-12 order-2 col-md-6 col-lg-4 offset-lg-2">
       <a class="btn btn-primary btn-lg guidance-button"
          href="https://navigator.unaids.org"
          target="_blank">
@@ -41,7 +41,7 @@
         <span class="button-text">{{_('Instructions to upload your<br />Country Estimates 2026 Data')}}</span>
       </a>
       </div>
-      <div class="hidden-xs hidden-sm col-md-6 col-lg-4 whats-next">
+      <div class="d-none d-md-block col-md-6 col-lg-4 whats-next">
         <h1>{{_('Unsure what to do next?')}}</h1>
         <h3>{{_('Use the HIV Estimates Navigator to guide you step-by-step through the HIV Estimates process, or click on one of our instruction pages opposite for videos and guidance.')}}</h3>
       </div>
@@ -61,7 +61,7 @@
 <div role="main">
   <div class="container">
     <div class="row">
-      <div class="col-xs-12 text-center">
+      <div class="col-12 text-center">
         <H2> {{_('Featured Organisations')}} </H2>
       </div>
     </div>
@@ -78,7 +78,7 @@
     {% set group = h.get_administrative_boundaries() %}
         {% if group.packages|length > 0 %}
           <div class="row">
-          <div class="col-xs-12 text-center">
+          <div class="col-12 text-center">
             <H2 class="admin-boundaries-group-header"> {{_('Geographic Health Boundaries')}} </H2>
               <div class="row row2">
                       <div class="col-md-12 col2">
@@ -91,7 +91,7 @@
                             {% if loop.first %}
                                 <div class="row">
                             {% endif %}
-                            <div class="col-xs-6 admin-boundaries-column left">
+                            <div class="col-6 admin-boundaries-column left">
                                 {% snippet 'snippets/package_item.html', package=package, admin_boundaries=true %}
                             </div>
                             {% if loop.last %}
@@ -101,7 +101,7 @@
                             {% if loop.first %}
                                 <div class="row">
                             {% endif %}
-                            <div class="col-xs-6 admin-boundaries-column right">
+                            <div class="col-6 admin-boundaries-column right">
                                 {% snippet 'snippets/package_item.html', package=package, admin_boundaries=true %}
                             </div>
                             {% if loop.last %}
@@ -127,38 +127,38 @@
 <div class="homepage-partners">
   <div class="container">
     <div class="row">
-      <div class="col-xs-12 text-center">
+      <div class="col-12 text-center">
         <H2> {{_('The AIDS Data Repository is a project by')}} </H2>
       </div>
     </div>
     <div class="row">
-      <div class="col-xs-12 text-center">
+      <div class="col-12 text-center">
         <a class="unaids-logo" href="https://www.unaids.org"  target="_blank">
             <img src="{{ h.url_for_static('/unaids.png') }}" alt="aim" width="80%" />
           </a>
       </div>
     </div>
     <div class="row">
-      <div class="col-xs-12 text-center">
+      <div class="col-12 text-center">
         <H2> {{_('With support from')}} </H2>
       </div>
     </div>
     <div class="row">
-      <div class="col-xs-4">
+      <div class="col-4">
         <div class="text-center">
           <a class="" href="https://www.avenirhealth.org/"  target="_blank">
             <img class="avenir-logo" src="{{ h.url_for_static('/avenir.png') }}" alt="aim" width="80%" />
           </a>
         </div>
       </div>
-      <div class="col-xs-4">
+      <div class="col-4">
         <div class="text-center">
           <a class="" href="http://www.fjelltopp.org"  target="_blank">
             <img class="fjelltopp-logo" src="{{ h.url_for_static('/fjelltopp.png') }}" alt="aim" width="80%" />
           </a>
         </div>
       </div>
-      <div class="col-xs-4">
+      <div class="col-4">
         <div class="text-center" style="margin-top: 10px;">
           <a class="" href="https://www.imperial.ac.uk/"  target="_blank">
             <img class="imperial-logo" src="{{ h.url_for_static('/imperial.png') }}" alt="aim" width="80%" />

--- a/ckanext/unaids/theme/templates/organization/bulk_process.html
+++ b/ckanext/unaids/theme/templates/organization/bulk_process.html
@@ -38,18 +38,18 @@
                 <input type="checkbox" name="dataset_{{ package.id }}">
               </td>
               <td class="context">
-                <a href="{% url_for package.type ~ '.edit', id=package.name %}" class="edit pull-right">
+                <a href="{% url_for package.type ~ '.edit', id=package.name %}" class="edit float-end">
                   {{ _('Edit') }}
                 </a>
                 <h3 class="dataset-heading">
                   {{ h.link_to(h.truncate(title, truncate_title), h.url_for(package.type ~ '.read', id=package.name)) }}
                   {% if package.get('state', '').startswith('draft') %}
-                    <span class="label label-info">{{ _('Draft') }}</span>
+                    <span class="badge bg-info">{{ _('Draft') }}</span>
                   {% elif package.get('state', '').startswith('deleted') %}
-                    <span class="label label-danger">{{ _('Deleted') }}</span>
+                    <span class="badge bg-danger">{{ _('Deleted') }}</span>
                   {% endif %}
                   {% if package.private %}
-                    <span class="label label-danger">{{ _('Private') }}</span>
+                    <span class="badge bg-danger">{{ _('Private') }}</span>
                   {% endif %}
                 </h3>
                 {% if notes %}

--- a/ckanext/unaids/theme/templates/organization/member_new.html
+++ b/ckanext/unaids/theme/templates/organization/member_new.html
@@ -35,7 +35,7 @@
 
   <div class="form-actions">
     {% if user %}
-      <a href="{{ h.url_for(group_type + '_member_delete', id=c.group_dict.id, user=user_id) }}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}">{{ _('Delete') }}</a>
+      <a href="{{ h.url_for(group_type + '_member_delete', id=c.group_dict.id, user=user_id) }}" class="btn btn-danger float-start" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}">{{ _('Delete') }}</a>
       <button class="btn btn-primary" type="submit" name="submit" >
         {{ _('Update Member') }}
       </button>

--- a/ckanext/unaids/theme/templates/organization/members.html
+++ b/ckanext/unaids/theme/templates/organization/members.html
@@ -75,7 +75,7 @@
           <td>{{ affiliation }} <br /> <span class="small"> {{ job_title }} </span></td>
           <td>
             {{ role }}
-            <div class="btn-group pull-right">
+            <div class="btn-group float-end">
                 <a class="btn btn-default btn-sm" href="{{ h.url_for(group_type + '.member_new', id=group_dict.id, user=user_id) }}" title="{{ _('Edit') }}">
                 <i class="fa fa-wrench"></i>
               </a>

--- a/ckanext/unaids/theme/templates/package/collaborators/collaborator_new.html
+++ b/ckanext/unaids/theme/templates/package/collaborators/collaborator_new.html
@@ -31,7 +31,7 @@
 
     <div class="form-actions">
       {% if user %}
-        <a href="{{ h.url_for('dataset.collaborator_delete', id=pkg_dict.id, user_id=user.name) }}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this collaborator?') }}">{{ _('Delete') }}</a>
+        <a href="{{ h.url_for('dataset.collaborator_delete', id=pkg_dict.id, user_id=user.name) }}" class="btn btn-danger float-start" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this collaborator?') }}">{{ _('Delete') }}</a>
         <button class="btn btn-primary" type="submit" name="submit" >
           {{ _('Update Collaborator') }}
         </button>

--- a/ckanext/unaids/theme/templates/package/read.html
+++ b/ckanext/unaids/theme/templates/package/read.html
@@ -58,7 +58,7 @@
   {% endblock %}
   {# FIXME why is this here? seems wrong #}
   <span class="insert-comment-thread"></span>
-  <button class="download-all btn btn-primary dropdown-toggle pull-right hidden"
+  <button class="download-all btn btn-primary dropdown-toggle float-end hidden"
      data-module="download_all" data-module-files='{{h.get_all_package_downloads(pkg)}}'>
     <i class="fa fa-download"></i>
     {{ _('Download All') }}

--- a/ckanext/unaids/theme/templates/package/read.html
+++ b/ckanext/unaids/theme/templates/package/read.html
@@ -58,7 +58,7 @@
   {% endblock %}
   {# FIXME why is this here? seems wrong #}
   <span class="insert-comment-thread"></span>
-  <button class="download-all btn btn-primary dropdown-toggle float-end hidden"
+  <button class="download-all btn btn-primary dropdown-toggle float-end d-none"
      data-module="download_all" data-module-files='{{h.get_all_package_downloads(pkg)}}'>
     <i class="fa fa-download"></i>
     {{ _('Download All') }}

--- a/ckanext/unaids/theme/templates/package/read_base.html
+++ b/ckanext/unaids/theme/templates/package/read_base.html
@@ -20,7 +20,7 @@
         {{_('Unlock')}}
       </a>
     {% elif pkg.get('locked')  %}
-      <a class="btn btn-danger" disabled href="#" data-module="tooltips" data-bs-toggle="tooltip" data-placement="left" title="{{_('A system administrator has made this dataset read-only.')}}">
+      <a class="btn btn-danger" disabled href="#" data-module="tooltips" data-bs-toggle="tooltip" data-bs-placement="left" title="{{_('A system administrator has made this dataset read-only.')}}">
         <i class="fa fa-lock"></i>
         {{_('Locked')}}
       </a>

--- a/ckanext/unaids/theme/templates/package/read_base.html
+++ b/ckanext/unaids/theme/templates/package/read_base.html
@@ -20,7 +20,7 @@
         {{_('Unlock')}}
       </a>
     {% elif pkg.get('locked')  %}
-      <a class="btn btn-danger" disabled href="#" data-module="tooltips" data-toggle="tooltip" data-placement="left" title="{{_('A system administrator has made this dataset read-only.')}}">
+      <a class="btn btn-danger" disabled href="#" data-module="tooltips" data-bs-toggle="tooltip" data-placement="left" title="{{_('A system administrator has made this dataset read-only.')}}">
         <i class="fa fa-lock"></i>
         {{_('Locked')}}
       </a>

--- a/ckanext/unaids/theme/templates/package/releases/base.html
+++ b/ckanext/unaids/theme/templates/package/releases/base.html
@@ -4,7 +4,7 @@
 <form method="POST">
     <div class="modal-dialog">
         <div class="row">
-            <div class="col-md-8 col-md-offset-2">
+            <div class="col-md-8 offset-md-2">
                 <div class="modal-content">
                     <div class="modal-header">
                         <h4 class="modal-title">

--- a/ckanext/unaids/theme/templates/package/releases/list.html
+++ b/ckanext/unaids/theme/templates/package/releases/list.html
@@ -20,7 +20,7 @@
             <a href="{{ urls.create_from_latest_version }}" class="btn btn-primary">
                 <i class="fa fa-plus-square"></i> <span>{{ _('Add Release') }}</span>
             </a>
-            <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+            <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown">
                 <span class="caret"></span>
             </button>
             <ul class="dropdown-menu">
@@ -63,7 +63,7 @@
                 <tr>
                     <td>
                         <div class="row vertical-align">
-                            <div class="col-xs-12 col-md-6">
+                            <div class="col-12 col-md-6">
                                 <div class="release-title"><h4><i class="fa fa-tag text-muted fa-fw"></i><a href="{{ h.url_for('dataset.read', id=pkg_dict.name, activity_id=release.activity_id) }}">{{ release.name }}</a></h4></div>
                                 {% if release.notes %}
                                     <div class="text-muted release-notes">{{ release.notes }}</div>
@@ -73,7 +73,7 @@
                             <div class="col-md-3">
                                 <div class="release-date"><span title="{{ h.render_datetime(release.created, with_hours=True) }}">{{ h.time_ago_from_timestamp(release.created) }}</span></div>
                             </div>
-                            <div class="col-xs-12 col-md-3">
+                            <div class="col-12 col-md-3">
                                 <div class="release-actions">
                                     <div class="btn-group btn-group-xs">
                                         <a

--- a/ckanext/unaids/theme/templates/package/releases/restore_or_delete.html
+++ b/ckanext/unaids/theme/templates/package/releases/restore_or_delete.html
@@ -7,7 +7,7 @@
     <br>
     <div id="RestoreOrDeleteReleaseContainer" class="thumbnail alert-info">
         <div class="row">
-            <div class="col-md-3 text-right">
+            <div class="col-md-3 text-end">
                 <i class="fa fa-code-fork fa-3x"></i>
             </div>
             <div class="col-md-9">

--- a/ckanext/unaids/theme/templates/package/snippets/bulk_file_uploader.html
+++ b/ckanext/unaids/theme/templates/package/snippets/bulk_file_uploader.html
@@ -4,7 +4,7 @@
         <span> {{ _('Bulk Upload') }}</span>
     </h2>
     <div class="module-content">
-        <button type="button" class="btn btn-success" data-toggle="modal" data-target="#BulkFileUploaderComponentModal">
+        <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#BulkFileUploaderComponentModal">
             <i className="fa fa-plus"></i>
             <span>{{ _('Add files') }}</span>
         </button>

--- a/ckanext/unaids/theme/templates/package/snippets/package_form.html
+++ b/ckanext/unaids/theme/templates/package/snippets/package_form.html
@@ -16,7 +16,7 @@
         <ul class="list-group">
             {% if h.check_access('package_delete', {'id': data.id}) and not data.state == 'deleted' %}
                 <li class="list-group-item">
-                    <a class="btn btn-danger pull-right"
+                    <a class="btn btn-danger float-end"
                        href="{% url_for dataset_type ~ '.delete', id=data.id %}"
                        data-module="confirm-action"
                        data-module-content="{{ _('Are you sure you want to delete this dataset?') }}">
@@ -38,7 +38,7 @@
                 {%- endif -%}
                 {%- endfor -%}
                 <li class="list-group-item">
-                    <a class="btn btn-danger pull-right"
+                    <a class="btn btn-danger float-end"
                        href="#"
                        data-module="transfer-dataset"
                        data-module-orgs='{{transfer_options|tojson}}'
@@ -51,7 +51,7 @@
             {% endif %}
             {% if h.check_access('dataset_lock') and h.dataset_lockable(data.id) %}
                 <li class="list-group-item">
-                    <a class="btn btn-danger pull-right"
+                    <a class="btn btn-danger float-end"
                        href="{% url_for 'dataset_lock.lock', dataset_id=data.id %}"
                        data-module="confirm-action"
                        data-module-content="{{ _('Are you sure you want to lock this dataset?') }}">

--- a/ckanext/unaids/theme/templates/request/show.html
+++ b/ckanext/unaids/theme/templates/request/show.html
@@ -56,7 +56,7 @@
       </table>
       <div class="form-actions">
       {% set locale = h.dump_json({'content': _('Are you sure you want approve this request?')}) %}
-     <a id="request_approve_url" href="{{ h.url_for('member_request.approve', mrequest_id=membership.id) }}" class="btn btn-primary  pull-left" data-module="confirm-action" data-module-i18n="{{ locale }}">{{ _('Approve') }}</a>
+     <a id="request_approve_url" href="{{ h.url_for('member_request.approve', mrequest_id=membership.id) }}" class="btn btn-primary  float-start" data-module="confirm-action" data-module-i18n="{{ locale }}">{{ _('Approve') }}</a>
       
       {% set locale = h.dump_json({'content': _('Are you sure you want reject this request?')}) %}
           <a id="request_reject_url" href="{{ h.url_for('member_request.reject', mrequest_id=membership.id) }}" class="btn btn-danger" data-module="confirm-action" data-module-i18n="{{ locale }}">{{ _('Reject') }}</a>

--- a/ckanext/unaids/theme/templates/scheming/form_snippets/org_to_allow_transfer_to.html
+++ b/ckanext/unaids/theme/templates/scheming/form_snippets/org_to_allow_transfer_to.html
@@ -26,7 +26,7 @@
   <div>
     <a
       class="btn btn-default"
-      data-toggle="collapse"
+      data-bs-toggle="collapse"
       href="#transfer_dataset_collapse"
       role="button"
       aria-expanded="false"

--- a/ckanext/unaids/theme/templates/scheming/form_snippets/text_template.html
+++ b/ckanext/unaids/theme/templates/scheming/form_snippets/text_template.html
@@ -14,7 +14,7 @@
          data-module-update='#field-{{field.field_name}}'>
       {{h.scheming_language_text(data[field.form_placeholder])}}
     </div>
-    <input class="form-control hidden"
+    <input class="form-control d-none"
            id="{{'field-' + field.field_name}}"
            name="{{field.field_name}}"
            value="{{data[field.field_name]}}"

--- a/ckanext/unaids/theme/templates/snippets/dataset_selector.html
+++ b/ckanext/unaids/theme/templates/snippets/dataset_selector.html
@@ -1,5 +1,5 @@
 <div class="dropdown">
-  <button class="btn btn-primary dropdown-toggle" type="button" id="addDatasetMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button class="btn btn-primary dropdown-toggle" type="button" id="addDatasetMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <i class="fa fa-plus-square"></i> {{_('Add Dataset')}}
   </button>
   <div class="dropdown-menu" aria-labelledby="addDatasetMenuButton">

--- a/ckanext/unaids/theme/templates/user/edit_user_form.html
+++ b/ckanext/unaids/theme/templates/user/edit_user_form.html
@@ -11,7 +11,7 @@
     <div class="panel panel-default">
       <div class="panel-body">
         <div class="row">
-          <div class="col-xs-6 no-top-padding">
+          <div class="col-6 no-top-padding">
               <ul class="list-unstyled">
                   <li><strong>{{ data.fullname }}</strong> ({{ data.name }})</li>
                   <li>{{ data.email }}</li>
@@ -22,7 +22,7 @@
           </div>
         </div>
           <div class="row">
-          <div class="col-xs-12 text-right no-bottom-padding">
+          <div class="col-12 text-right no-bottom-padding">
             <a class="btn btn-primary" href="{{ h.get_profile_editor_url() }}">{{ _('Update data') }}</a>
           </div>
         </div>
@@ -57,7 +57,7 @@
   <div class="form-actions">
     {% block delete_button %}
       {% if h.check_access('user_delete', {'id': data.id})  %}
-        <a class="btn btn-danger pull-left" href="{% url_for 'user_delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this User?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+        <a class="btn btn-danger float-start" href="{% url_for 'user_delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this User?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
       {% endif %}
     {% endblock %}
     {% block generate_button %}

--- a/ckanext/unaids/theme/templates/user/edit_user_form.html
+++ b/ckanext/unaids/theme/templates/user/edit_user_form.html
@@ -22,7 +22,7 @@
           </div>
         </div>
           <div class="row">
-          <div class="col-12 text-right no-bottom-padding">
+          <div class="col-12 text-end no-bottom-padding">
             <a class="btn btn-primary" href="{{ h.get_profile_editor_url() }}">{{ _('Update data') }}</a>
           </div>
         </div>
@@ -45,7 +45,7 @@
 
   </fieldset>
 
-   <div class="hidden">
+   <div class="d-none">
       <!-- Hidden inputs required for the CKAN flask view to work -->
       <input type="hidden" name="old_password"/>
       <input type="hidden" name="password1"/>


### PR DESCRIPTION
## Summary

**Single cause: CKAN 2.11 ships Bootstrap 5 (CKAN 2.9 was Bootstrap 3).** Every change in this PR is a mechanical Bootstrap 3 → 5 class/attribute rename required for our existing templates to keep rendering correctly. **There is no visual redesign, no new layouts, and no colour or spacing changes** — only renames of classes/attributes that Bootstrap 5 removed or renamed.

This directly answers the client's question *"are these all to do with the bootstrap version changing? If so, that could be 1 PR"* — yes, and this is that one PR. Changes for other reasons (CSRF, activity-plugin routes) are split into their own PRs (#329, #330).

> Note: the large "new templating" from the original branch (the icon double-encoding rewrite — ~18 template overrides + a custom `helpers.py`) is **deliberately not here**. It was investigated and dropped: the underlying bug does not reproduce on CKAN 2.11.4, so those overrides are unnecessary.

## What changed (all BS3 → BS5 renames)

- `pull-right` / `pull-left` → `float-end` / `float-start`
- `data-toggle` / `data-target` → `data-bs-toggle` / `data-bs-target` (dropdowns, modal, collapse, tooltip)
- `data-placement` → `data-bs-placement`
- `text-right` → `text-end`
- `hidden` → `d-none` (incl. the Download All button + its `download_all.js` toggle, so show/hide works again)
- `col-xs-*` → `col-*`, `col-lg-offset-2` → `offset-lg-2`, `order-xs-2` → `order-2`, `hidden-xs hidden-sm` → `d-none d-md-block`
- `label label-info` / `label-danger` → `badge bg-info` / `bg-danger`
- format-chip CSS: added parallel `.badge[data-format]` selectors alongside the existing `.label[data-format]` ones so the colour coding still applies under BS5 markup (no colour values changed)

Plus one CKAN-2.11 (not Bootstrap) item that belongs with the homepage template work:
- New `home/index.html` shim that includes our `home/layout1.html`. CKAN 2.11 removed the `ckan.homepage_style` config that previously loaded our custom homepage; without this shim the homepage silently falls back to core CKAN's.

## Completeness

A repo-wide sweep was run for leftover BS3 classes (`pull-*`, `col-xs-*`, `hidden-*`, `data-toggle`, `data-placement`, `text-right`, `.hidden`, `label-*`). All functional leftovers are converted. Remaining `.label[data-format]` selectors are intentional (kept alongside the new `.badge[data-format]` for backwards compatibility); a `.col-xs-*` selector list in `custom.css` is a harmless padding rule (its `col-sm/md/lg` selectors still apply under BS5).

## Test plan

- [x] Full test suite green (160 passed / 1 skipped)
- [ ] Manual browser smoke: dropdowns open, dataset-transfer modal renders, format chips show in colour, Download All button hides/shows correctly, homepage shows the custom layout