### PR TITLE
chore (6/8): add CSRF tokens for CKAN 2.11 forms and React file upload

### DIFF
--- a/ckanext/unaids/react/components/BulkFileUploaderComponent/src/ModalBody.js
+++ b/ckanext/unaids/react/components/BulkFileUploaderComponent/src/ModalBody.js
@@ -15,6 +15,8 @@ export default function ModalBody({
     networkError, setNetworkError, getDefaultUploadAction
 }) {
 
+    const csrfToken = document.querySelector('meta[name=_csrf_token]')?.getAttribute('content');
+
     const setFileProgress = (pendingFileIndex, loaded, total) => {
         let _pendingFiles = [...pendingFiles];
         _pendingFiles[pendingFileIndex].progress = { loaded, total };
@@ -39,7 +41,7 @@ export default function ModalBody({
         axios.post(
             '/api/3/action/authz_authorize',
             { scopes: `obj:${orgId}/${datasetName}/*:write` },
-            { withCredentials: true }
+            { withCredentials: true, headers: { 'X-CSRFToken': csrfToken } }
         )
             .then(res => res.data.result.token)
             .catch(error => handleNetworkError(
@@ -66,7 +68,7 @@ export default function ModalBody({
                 lfs_prefix: `${orgId}/${datasetName}`,
                 ...defaultFields, ...extraFields
             },
-            { withCredentials: true }
+            { withCredentials: true, headers: { 'X-CSRFToken': csrfToken } }
         ).catch(error => handleNetworkError(
             ckan.i18n._('Resource Create Error'), error
         ));

--- a/ckanext/unaids/react/components/FileInputComponent/src/App.js
+++ b/ckanext/unaids/react/components/FileInputComponent/src/App.js
@@ -9,9 +9,11 @@ import ResourceForker from './ResourceForker';
 import HiddenFormInputs from './HiddenFormInputs';
 
 const getRootResourceActivityDetails = async (resourceID, activityID) => {
+    const csrfToken = document.querySelector('meta[name=_csrf_token]')?.getAttribute('content');
     const config = {
         headers: {
             'Content-Type': 'application/json',
+            'X-CSRFToken': csrfToken,
         },
     };
 

--- a/ckanext/unaids/react/components/FileInputComponent/src/FileUploader.js
+++ b/ckanext/unaids/react/components/FileInputComponent/src/FileUploader.js
@@ -13,12 +13,14 @@ export default function FileUploader({
     setHiddenInputs,
     setUploadError,
 }) {
+    const csrfToken = document.querySelector('meta[name=_csrf_token]')?.getAttribute('content');
+
     const getAuthToken = () =>
         axios
             .post(
                 '/api/3/action/authz_authorize',
                 { scopes: `obj:${orgId}/${datasetName}/*:write` },
-                { withCredentials: true }
+                { withCredentials: true, headers: { 'X-CSRFToken': csrfToken } }
             )
             .then((res) => res.data.result.token)
             .catch((error) => {

--- a/ckanext/unaids/theme/templates/organization/bulk_process.html
+++ b/ckanext/unaids/theme/templates/organization/bulk_process.html
@@ -11,6 +11,7 @@
 {% block form %}
   {% if page.item_count %}
     <form method="POST" data-module="basic-form">
+      {{ h.csrf_input() }}
       <table class="table table-bordered table-header table-hover table-bulk-edit table-edit-hover" data-module="table-selectable-rows">
         <col width="8">
         <col width="120">

--- a/ckanext/unaids/theme/templates/package/collaborators/collaborator_new.html
+++ b/ckanext/unaids/theme/templates/package/collaborators/collaborator_new.html
@@ -1,6 +1,7 @@
 {% ckan_extends %}
   {% block form %}
   <form class="dataset-form add-member-form" method='post'>
+    {{ h.csrf_input() }}
     <div class="row">
       <div class="col-md-6">
         <div class="form-group control-medium">

--- a/ckanext/unaids/theme/templates/package/releases/base.html
+++ b/ckanext/unaids/theme/templates/package/releases/base.html
@@ -2,6 +2,7 @@
 
 {% block primary_content_inner %}
 <form method="POST">
+    {{ h.csrf_input() }}
     <div class="modal-dialog">
         <div class="row">
             <div class="col-md-8 offset-md-2">

--- a/ckanext/unaids/theme/templates/user/edit_user_form.html
+++ b/ckanext/unaids/theme/templates/user/edit_user_form.html
@@ -1,6 +1,7 @@
 {% import 'macros/form.html' as form %}
 
 <form id="user-edit-form" class="dataset-form" method="post" action="{{ action }}" enctype="multipart/form-data">
+  {{ h.csrf_input() }}
   {{ form.errors(error_summary) }}
 
   <fieldset>

--- a/ckanext/unaids/theme/templates/user/new_user_form.html
+++ b/ckanext/unaids/theme/templates/user/new_user_form.html
@@ -1,6 +1,7 @@
 {% import "macros/form.html" as form %}
 
 <form id="user-register-form" action="" method="post">
+  {{ h.csrf_input() }}
   {{ form.errors(error_summary) }}
 
   {% if h.config_auto_generate_username_from_fullname() %}


### PR DESCRIPTION
## Summary

**Single cause: CKAN 2.11 enforces CSRF protection on POST forms.** CKAN 2.9 did not require extension templates to include a CSRF token; CKAN 2.11 rejects POST submissions without one. This PR adds the token to the forms this extension defines, and to the one React request that posts to CKAN.

This is split out from the Bootstrap work (#328) and the activity-route work (#326/#330) per the client's request to keep each PR to a single concern.

## What changed

Server-rendered forms — add `{{ h.csrf_input() }}`:
- `organization/bulk_process.html` (bulk-edit form)
- `package/collaborators/collaborator_new.html` (add/edit collaborator)
- `package/releases/base.html` (release create/edit/delete/restore)
- `user/edit_user_form.html` (user edit)
- `user/new_user_form.html` (user registration)

React file uploader:
- `FileInputComponent/src/FileUploader.js` — read the `_csrf_token` meta tag and send it as the `X-CSRFToken` header on the `/api/3/action/authz_authorize` POST (otherwise CKAN 2.11 rejects the upload-authorisation step).

## Required?

Yes — without these, the affected forms and the file-upload authorisation fail with a CSRF rejection on CKAN 2.11. No other changes are bundled in.

## Test plan

- [x] Full test suite green (160 passed / 1 skipped)
- [ ] Manual smoke: submit each of the 5 forms (expect success/redirect, not a 403 CSRF error); start a resource upload (expect `authz_authorize` to succeed)