### PR TITLE
chore (7/8): fix organization nav routes and group_dict accessor for CKAN 2.11

### DIFF
--- a/ckanext/unaids/theme/templates/organization/read_base.html
+++ b/ckanext/unaids/theme/templates/organization/read_base.html
@@ -1,13 +1,13 @@
 {% ckan_extends %}
 
 {% block content_primary_nav %}
-  {{ h.build_nav_icon(group_type + '_read', _('Datasets'), id=c.group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '.read', _('Datasets'), id=group_dict.name) }}
   <li>
-    <a  href="{{ h.url_for('/harvest', organization=c.group_dict.name) }}">
+    <a href="{{ h.url_for('/harvest', organization=group_dict.name) }}">
       <i class="fa fa-database"></i>
       {{ _('DHIS2 Sources') }}
     </a>
   </li>
-  {{ h.build_nav_icon(group_type + '_activity', _('Activity Stream'), id=c.group_dict.name, offset=0) }}
-  {{ h.build_nav_icon(group_type + '_about', _('About'), id=c.group_dict.name) }}
+  {{ h.build_nav_icon('activity.organization_activity', _('Activity Stream'), id=group_dict.name, offset=0) }}
+  {{ h.build_nav_icon(group_type + '.about', _('About'), id=group_dict.name) }}
 {% endblock %}


### PR DESCRIPTION
## Summary

**Single cause: CKAN 2.11 moved the activity stream into its own plugin and renamed its routes; it also deprecated the Pylons `c` global.** This PR updates `organization/read_base.html` so the org page's nav renders again under CKAN 2.11.

Split from the Bootstrap work (#328) and CSRF work (#329) per the client's request to keep each PR to a single concern. (The equivalent dataset-page route renames live in #326, alongside the test-suite changes that needed them.)

## What changed (`organization/read_base.html`)

- Route names: underscore-style → Flask blueprint dot-style — `organization_read` → `organization.read`, `organization_about` → `organization.about`.
- Activity route: `organization_activity` → `activity.organization_activity` (the route moved into the activity blueprint in 2.11).
- Deprecated accessor: `c.group_dict` → `group_dict` (CKAN 2.11 passes `group_dict` to the template; the Pylons `c` global is deprecated).

## Required?

Yes — under CKAN 2.11 the old route names no longer resolve (the nav links would error), and the activity route only exists under the activity blueprint now.

## Scope note

Intentionally limited to this one template. Other templates that still reference `c.group_dict` (e.g. `organization/member_new.html`) are left as-is — they keep working via CKAN's deprecated-`c` compatibility shim and did not otherwise need touching. We only modernised `c.group_dict` where we already had to fix the routes, to keep the change need-driven.

## Test plan

- [x] Full test suite green (160 passed / 1 skipped)
- [ ] Manual smoke: visit /organization/<name> — nav shows Datasets / DHIS2 Sources / Activity Stream / About and each link resolves