### PR TITLE
fix(theme): restore About link in top navbar

### DIFF
--- a/ckanext/unaids/theme/templates/header.html
+++ b/ckanext/unaids/theme/templates/header.html
@@ -17,6 +17,11 @@
 {% block header_site_navigation_tabs %}
     {{ super() }}
     <li>
+        <a href="{{ h.get_localized_page_url('about') }}">
+            {{ _('About') }}
+        </a>
+    </li>
+    <li>
         <a  href="{{h.get_localized_page_url('inputs-unaids')}}">
             {{_('2026 Instructions')}}
         </a>


### PR DESCRIPTION
## Summary

After #331 (CKAN 2.11 post-migration cleanup), the **About** link disappeared from the masthead.

The previous `build_pages_nav_main` override looped through every `ckanext-pages` CMS page and appended each as a navbar `<li>`. That loop was the reason the production About link (`/en/pages/about`) appeared. The cleanup PR removed the loop (intentionally — it also dumped every other CMS page into the navbar, causing clutter and a duplicate About), but lost the About link in the process.

This PR restores the About link explicitly in `header.html`, alongside the existing **2026 Instructions** link added the same way. No bulk dump — only the entries we actually want.

## Changes

- `ckanext/unaids/theme/templates/header.html` — add an `<li>` linking to `h.get_localized_page_url('about')` inside `header_site_navigation_tabs`, above the 2026 Instructions link.

## Required deployment config change (NOT in this repo)

To match production behavior (single About link pointing at the CMS page), the deployment's `ckan.ini` must also set:

\`\`\`ini
ckanext.pages.about_menu = false
\`\`\`

Without this, the navbar shows **two** About entries:
- `/en/about` — core CKAN About route (rendered by core's nav template via `super()`)
- `/en/pages/about` — CMS About page (added by this PR)

Setting `ckanext.pages.about_menu = false` causes `ckanext-pages` (and our wrapper) to filter out the core `home.about` arg before `core_build_nav_main` runs, leaving only the CMS About from this PR. This is the same flag prod has historically relied on; it is misleadingly named — it does **not** disable the CMS About, only the core CKAN About arg passed by the template.

This config change should be applied in the ADX deployment repo's CKAN ini.

## Test plan

- [ ] With `ckanext.pages.about_menu = false` in `ckan.ini`, restart CKAN and confirm the masthead shows **one** About link pointing at `/en/pages/about`.
- [ ] Confirm "2026 Instructions" still appears next to About.
- [ ] Confirm the About page renders the existing CMS content unchanged.
- [ ] Confirm the language-aware URL works on `/fr` and `/pt_PT` (should resolve to the localized CMS slug, same as 2026 Instructions does today).