### PR TITLE
Fix: Add missing CSRF token to organization Add Member form

### DIFF
--- a/ckanext/unaids/theme/templates/organization/member_new.html
+++ b/ckanext/unaids/theme/templates/organization/member_new.html
@@ -8,6 +8,7 @@
   {{_('Add a ckan user to your organisation by searching for their username and assigning them a role. See the note on the left about role descriptions.')}}
 </p>
 <form class="dataset-form add-member-form" method='post'>
+  {{ h.csrf_input() }}
   <div class="row">
     <div class="col-md-5">
       <div class="form-group control-medium">


### PR DESCRIPTION
## Summary

CKAN 2.11 enforces CSRF protection on POST forms. PR #329 (`chore (6/8): add CSRF tokens for CKAN 2.11 forms`) added `{{ h.csrf_input() }}` to most extension forms but missed `organization/member_new.html`, which still causes:

```
400 Bad Request: The CSRF token is missing.
```

whenever an organization admin submits the **Add Member** / **Edit Member** form.

## Root cause

Confirmed via live reproduction on `dev-adr.unaids.org`: fetched the raw server-rendered HTML for `organization/member_new.html` and confirmed no `csrf_token` hidden input is present in the `<form>`, while the same page's other forms (logout, language switcher) correctly include it. Checked all 8 merged CKAN-2.11-migration PRs (#324-#331) — none of them add the token to this file. PR #328 (Bootstrap 5 migration) touched this file only for a `pull-left` → `float-start` class rename, unrelated to CSRF.

## Fix

One line, matching the exact pattern used by PR #329 elsewhere: add `{{ h.csrf_input() }}` immediately after the opening `<form>` tag.

## Scope note

`group/member_new.html` does **not** need the same fix — it doesn't exist as a theme override on `master` (only exists on an unrelated unmerged branch), so group Add Member already falls back to CKAN core's template, which already has the CSRF field.