### PR TITLE
Fix: Add missing CSRF token to organization Add Member form

### DIFF
--- a/ckanext/unaids/theme/templates/organization/member_new.html
+++ b/ckanext/unaids/theme/templates/organization/member_new.html
@@ -8,6 +8,7 @@
   {{_('Add a ckan user to your organisation by searching for their username and assigning them a role. See the note on the left about role descriptions.')}}
 </p>
 <form class="dataset-form add-member-form" method='post'>
+  {{ h.csrf_input() }}
   <div class="row">
     <div class="col-md-5">
       <div class="form-group control-medium">


### PR DESCRIPTION
## Summary

CKAN 2.11 enforces CSRF protection on POST forms. `organization/member_new.html` is missing the token, causing:

```
400 Bad Request: The CSRF token is missing.
```

whenever an organization admin submits the **Add Member** / **Edit Member** form. Reproduced live on `dev-adr.unaids.org` — confirmed via raw server response that no `csrf_token` hidden input exists in this form's `<form>`, while other forms on the same page (logout, language switcher) correctly include it.

## Fix

One line, matching the pattern used elsewhere in this codebase for CSRF tokens: add `{{ h.csrf_input() }}` immediately after the opening `<form>` tag.

## Scope note

`group/member_new.html` does **not** need the same fix — it doesn't exist as a theme override on `development`, so group Add Member already falls back to CKAN core's template, which already has the CSRF field.

Missed in #329 i think?
