### PR TITLE
Fix: set login_via_auth_header flag for OAuth2 Bearer token auth to avoid CSRF rejection

### DIFF
--- a/ckanext/unaids/auth_logic.py
+++ b/ckanext/unaids/auth_logic.py
@@ -41,6 +41,9 @@ def access_token_present_and_valid_and_user_authorized():
         g.userobj = user
         g.user = user.name
         login_user(user)
+        # Matches CKAN's own API-token request_loader flag (ckan/config/middleware/flask_app.py),
+        # which the before_request hook checks to exempt header-authenticated requests from CSRF.
+        g.login_via_auth_header = True
 
         return True
 

--- a/ckanext/unaids/tests/test_auth_logic.py
+++ b/ckanext/unaids/tests/test_auth_logic.py
@@ -66,6 +66,7 @@ class TestAccessTokenPresentAndValidAndUserAuthorized():
         assert auth_logic.access_token_present_and_valid_and_user_authorized()
         assert g.userobj == user
         assert g.user == "Some name"
+        assert g.login_via_auth_header is True
         find_user_by_saml_id.assert_called_once_with(user_id)
         validate_and_decode_token.assert_called_once_with(token_from_request)
 


### PR DESCRIPTION
## Problem

API calls authenticated via an Auth0 Bearer JWT (e.g. Naomi's "Upload to ADR" calling `resource_create`) were rejected with a 400 "The CSRF token is missing" error on any state-changing HTTP method (POST/PUT/PATCH/DELETE).

## Root cause

CKAN's Flask app only exempts a request from flask-wtf CSRF protection when `g.login_via_auth_header` is set (`ckan/config/middleware/flask_app.py`). That flag is normally set by CKAN core's own flask-login `request_loader` when a request authenticates via a CKAN API token in the `Authorization` header.

This extension's OAuth2 `IAuthenticator` (`access_token_present_and_valid_and_user_authorized` in `auth_logic.py`) authenticates Auth0 Bearer JWTs by calling `login_user()` directly, which succeeds before flask-login's own request_loader ever runs — so `g.login_via_auth_header` was never set, and the CSRF exemption never kicked in.

This is the same bug class as the earlier CSRF fix for the FileUploader form (#337-adjacent), but on a different code path: that fix addressed a browser session request missing an explicit CSRF token; this one addresses a machine/API Bearer-token request that should be exempt from CSRF checks entirely but wasn't being recognized as such.

## Fix

Set `g.login_via_auth_header = True` immediately after successful Bearer JWT authentication, mirroring what CKAN core's own API-token request_loader does. This lets the existing exemption logic in `flask_app.py` correctly waive CSRF for these header-authenticated requests.

## Testing

- Added an assertion to the existing `test_should_set_user_when_token_correct_and_user_authorized` test confirming the flag is set.
- Ran the full `test_auth_logic.py` suite in the project's docker CKAN container: 20 passed, 0 failed.
- Audited the rest of the codebase for the same bug class (other `login_user()` call sites, other custom auth mechanisms) — no other live instances found. (saml2auth's own `login_user()` call doesn't set the flag either, but its routes are covered by CKAN's blanket `ckan.csrf_protection.ignore_extensions` exemption for extension-registered blueprints, so it isn't affected.)