### PR TITLE
Fix resource list nesting from markdown descriptions

### DIFF
--- a/ckanext/unaids/theme/templates/package/snippets/resource_item.html
+++ b/ckanext/unaids/theme/templates/package/snippets/resource_item.html
@@ -11,7 +11,7 @@
 {% block resource_item_description %}
   {% if res.description %}
     <p class="description">
-        {{ h.markdown_extract(h.get_translated(res, 'description'), extract_length=80) }}
+        {{ h.render_markdown(h.get_translated(res, 'description')) | striptags | truncate(80) }}
     </p>
   {% endif %}
 


### PR DESCRIPTION
## Problem

In the dataset core-resources listing, a resource whose **description** contains a markdown bullet list rendered the *following* resources indented/nested underneath it (as sub-bullets) instead of a flat list.

Root cause: `markdown_extract` renders the description to HTML, then truncates the **HTML string** to 80 chars. Bleach's allowlist keeps structural tags (`<ul>/<li>`), so the truncation can cut the list mid-tag and emit an **unclosed `<ul>`**. Since each resource is a sibling `<li class="resource-item">` inside a shared `<ul class="resource-list">`, the browser adopts every following resource `<li>` into that open list.

## Fix

```diff
- {{ h.markdown_extract(h.get_translated(res, 'description'), extract_length=80) }}
+ {{ h.render_markdown(h.get_translated(res, 'description')) | striptags | truncate(80) }}
```

Before:
<img width="896" height="464" alt="image" src="https://github.com/user-attachments/assets/01112add-b1bb-469e-9cae-521dcd5f6b56" />


After:
<img width="896" height="464" alt="image" src="https://github.com/user-attachments/assets/1c16fa00-0185-454c-92ad-e47592c6dcd3" />



Render the markdown, strip **all** tags to plain text, then truncate. The preview can never contain unbalanced HTML. Also safe against XSS: `striptags` yields a plain (non-`Markup`) string, which Jinja auto-escapes on output.

## Verification

Reproduced locally by setting a Geographic Data description to a markdown bullet list — the resources after it nested. After the fix the listing is flat (DOM: N top-level `li.resource-item`, 0 nested). Full formatted description is unaffected on the resource page.
