### PR TITLE
fix: restore activity-stream email notifications and cross-user profile edits

### DIFF
--- a/ckanext/unaids/assets/custom.css
+++ b/ckanext/unaids/assets/custom.css
@@ -776,6 +776,12 @@ float: right;
   width: 100%;
 }
 
+/* Exempt toggles: width:100% stretches them to the full field width, pushing their label onto the next line. */
+.dataset-form input[type="checkbox"],
+.dataset-form input[type="radio"] {
+  width: auto;
+}
+
 .avenir-logo {
   margin: -10px auto;
 }

--- a/ckanext/unaids/tests/test_user_edit_form.py
+++ b/ckanext/unaids/tests/test_user_edit_form.py
@@ -8,12 +8,25 @@ from ckan.tests import factories
 NOTIFICATIONS_INPUT = re.compile(
     r'<input[^>]*name="activity_streams_email_notifications"[^>]*>'
 )
+SYSADMIN_PASSWORD_INPUT = re.compile(r'<input[^>]*name="old_password"[^>]*>')
 
 
-def notifications_checkbox(response):
-    match = NOTIFICATIONS_INPUT.search(response.body)
-    assert match, "notification checkbox is missing from the form"
+def find_input(pattern, response, description):
+    match = pattern.search(response.body)
+    assert match, "{} is missing from the form".format(description)
     return match.group(0)
+
+
+def is_checked(input_tag):
+    # Matching the bare attribute avoids counting a future data-checked.
+    return re.search(r'(?<![-\w])checked(?![-\w])', input_tag) is not None
+
+
+def user_edit_page(app, viewer, edited_user):
+    return app.get(
+        toolkit.url_for('user.edit', id=edited_user['name']),
+        extra_environ={'REMOTE_USER': viewer['name']}
+    )
 
 
 @pytest.mark.ckan_config(
@@ -23,32 +36,40 @@ def notifications_checkbox(response):
 class TestUserEditForm(object):
     def test_notifications_checkbox_reflects_the_edited_user(self, app):
         # Reading this from the logged-in user instead of the edited one lets a
-        # sysadmin's save overwrite the other user's stored preference.
-        sysadmin = factories.Sysadmin(
-            activity_streams_email_notifications=False)
-        subscribed_user = factories.User(
+        # sysadmin's save overwrite the other user's stored preference. Both
+        # directions are asserted so a hardcoded state cannot satisfy the test.
+        subscribed = factories.User(
             activity_streams_email_notifications=True)
+        unsubscribed = factories.User(
+            activity_streams_email_notifications=False)
+        subscribed_sysadmin = factories.Sysadmin(
+            activity_streams_email_notifications=True)
+        unsubscribed_sysadmin = factories.Sysadmin(
+            activity_streams_email_notifications=False)
 
-        response = app.get(
-            toolkit.url_for('user.edit', id=subscribed_user['name']),
-            extra_environ={'REMOTE_USER': sysadmin['name']}
-        )
+        subscribed_page = user_edit_page(app, unsubscribed_sysadmin, subscribed)
+        unsubscribed_page = user_edit_page(
+            app, subscribed_sysadmin, unsubscribed)
 
-        assert 'checked' in notifications_checkbox(response)
+        assert is_checked(find_input(
+            NOTIFICATIONS_INPUT, subscribed_page, "notification checkbox"))
+        assert not is_checked(find_input(
+            NOTIFICATIONS_INPUT, unsubscribed_page, "notification checkbox"))
 
     def test_sysadmin_password_shown_only_when_editing_someone_else(self, app):
         sysadmin = factories.Sysadmin()
         other_user = factories.User()
-        environ = {'REMOTE_USER': sysadmin['name']}
 
-        own_profile = app.get(
-            toolkit.url_for('user.edit', id=sysadmin['name']),
-            extra_environ=environ
-        )
-        other_profile = app.get(
-            toolkit.url_for('user.edit', id=other_user['name']),
-            extra_environ=environ
-        )
+        own_profile = user_edit_page(app, sysadmin, sysadmin)
+        other_profile = user_edit_page(app, sysadmin, other_user)
 
+        # A hidden or non-required field would leave cross-user saves unable to
+        # supply the password ckan/views/user.py demands.
+        password_input = find_input(
+            SYSADMIN_PASSWORD_INPUT, other_profile, "sysadmin password field")
+        assert 'type="password"' in password_input
+        assert 'required' in password_input
+
+        assert 'type="hidden"' in find_input(
+            SYSADMIN_PASSWORD_INPUT, own_profile, "old_password input")
         assert 'field-password-old' not in own_profile.body
-        assert 'field-password-old' in other_profile.body

--- a/ckanext/unaids/tests/test_user_edit_form.py
+++ b/ckanext/unaids/tests/test_user_edit_form.py
@@ -1,0 +1,54 @@
+"""Tests for the user edit form template."""
+import re
+import pytest
+import ckan.plugins.toolkit as toolkit
+
+from ckan.tests import factories
+
+NOTIFICATIONS_INPUT = re.compile(
+    r'<input[^>]*name="activity_streams_email_notifications"[^>]*>'
+)
+
+
+def notifications_checkbox(response):
+    match = NOTIFICATIONS_INPUT.search(response.body)
+    assert match, "notification checkbox is missing from the form"
+    return match.group(0)
+
+
+@pytest.mark.ckan_config(
+    'ckan.plugins', 'activity ytp_request unaids pages scheming_datasets')
+@pytest.mark.ckan_config('ckan.activity_streams_email_notifications', True)
+@pytest.mark.usefixtures('with_plugins')
+class TestUserEditForm(object):
+    def test_notifications_checkbox_reflects_the_edited_user(self, app):
+        # Reading this from the logged-in user instead of the edited one lets a
+        # sysadmin's save overwrite the other user's stored preference.
+        sysadmin = factories.Sysadmin(
+            activity_streams_email_notifications=False)
+        subscribed_user = factories.User(
+            activity_streams_email_notifications=True)
+
+        response = app.get(
+            toolkit.url_for('user.edit', id=subscribed_user['name']),
+            extra_environ={'REMOTE_USER': sysadmin['name']}
+        )
+
+        assert 'checked' in notifications_checkbox(response)
+
+    def test_sysadmin_password_shown_only_when_editing_someone_else(self, app):
+        sysadmin = factories.Sysadmin()
+        other_user = factories.User()
+        environ = {'REMOTE_USER': sysadmin['name']}
+
+        own_profile = app.get(
+            toolkit.url_for('user.edit', id=sysadmin['name']),
+            extra_environ=environ
+        )
+        other_profile = app.get(
+            toolkit.url_for('user.edit', id=other_user['name']),
+            extra_environ=environ
+        )
+
+        assert 'field-password-old' not in own_profile.body
+        assert 'field-password-old' in other_profile.body

--- a/ckanext/unaids/theme/templates/user/edit_user_form.html
+++ b/ckanext/unaids/theme/templates/user/edit_user_form.html
@@ -59,7 +59,7 @@
       <legend>{{ _('Sysadmin password') }}</legend>
       {# ckan/views/user.py treats email_changed as always True on a cross-user edit,
          so it requires the acting sysadmin's own password to authorize the save. #}
-      {{ form.input('old_password', type='password', label=_('Sysadmin Password'), id='field-password-old', value=data.oldpassword, error=errors.oldpassword, classes=['control-medium'], attrs={'autocomplete': 'off', 'class': 'form-control', 'required': ''}, is_required=true) }}
+      {{ form.input('old_password', type='password', label=_('Sysadmin Password'), id='field-password-old', error=errors.oldpassword, classes=['control-medium'], attrs={'autocomplete': 'off', 'class': 'form-control', 'required': ''}, is_required=true) }}
     </fieldset>
   {% else %}
     <input type="hidden" name="old_password"/>

--- a/ckanext/unaids/theme/templates/user/edit_user_form.html
+++ b/ckanext/unaids/theme/templates/user/edit_user_form.html
@@ -32,10 +32,10 @@
 
     {{ form.markdown('about', label=_('About'), id='field-about', value=data.about, error=errors.about, placeholder=_('A little information about yourself')) }}
 
-    {% if show_email_notifications %}
-      {% call form.checkbox('activity_streams_email_notifications', label=_('Subscribe to notification emails'), id='field-activity-streams-email-notifications', value=True, checked=g.userobj.activity_streams_email_notifications) %}
+    {% if h.activity_show_email_notifications() %}
+      {% call form.checkbox('activity_streams_email_notifications', label=_('Subscribe to notification emails'), id='field-activity-streams-email-notifications', value=True, checked=data.activity_streams_email_notifications) %}
       {% set helper_text = _("You will receive notification emails from {site_title}, e.g. when you have new activities on your dashboard."|string) %}
-      {{ form.info(helper_text.format(site_title=g.site_title), classes=['info-help-tight']) }}
+      {{ form.info(helper_text.format(site_title=g.site_title)) }}
       {% endcall %}
     {% endif %}
 
@@ -48,12 +48,22 @@
 
    <div class="d-none">
       <!-- Hidden inputs required for the CKAN flask view to work -->
-      <input type="hidden" name="old_password"/>
       <input type="hidden" name="password1"/>
       <input type="hidden" name="password2"/>
       <input type="hidden" name="email" value="{{data.email}}" />
       <input type="hidden" name="name" value="{{data.name}}" />
   </div>
+
+  {% if is_sysadmin and current_user.name != data.name %}
+    <fieldset>
+      <legend>{{ _('Sysadmin password') }}</legend>
+      {# ckan/views/user.py treats email_changed as always True on a cross-user edit,
+         so it requires the acting sysadmin's own password to authorize the save. #}
+      {{ form.input('old_password', type='password', label=_('Sysadmin Password'), id='field-password-old', value=data.oldpassword, error=errors.oldpassword, classes=['control-medium'], attrs={'autocomplete': 'off', 'class': 'form-control', 'required': ''}, is_required=true) }}
+    </fieldset>
+  {% else %}
+    <input type="hidden" name="old_password"/>
+  {% endif %}
 
   <div class="form-actions">
     {% block delete_button %}

--- a/ckanext/unaids/theme/templates/user/edit_user_form.html
+++ b/ckanext/unaids/theme/templates/user/edit_user_form.html
@@ -32,7 +32,7 @@
 
     {{ form.markdown('about', label=_('About'), id='field-about', value=data.about, error=errors.about, placeholder=_('A little information about yourself')) }}
 
-    {% if h.activity_show_email_notifications() %}
+    {% if 'activity_show_email_notifications' in h and h.activity_show_email_notifications() %}
       {% call form.checkbox('activity_streams_email_notifications', label=_('Subscribe to notification emails'), id='field-activity-streams-email-notifications', value=True, checked=data.activity_streams_email_notifications) %}
       {% set helper_text = _("You will receive notification emails from {site_title}, e.g. when you have new activities on your dashboard."|string) %}
       {{ form.info(helper_text.format(site_title=g.site_title)) }}


### PR DESCRIPTION
## Summary

Three faults in the user-edit form, all stemming from the CKAN 2.9 → 2.11 migration and a Dec 2022 crash fix - none crashed or logged anything, they just silently didn't work.

- **Email notification checkbox never rendered.** It gated on `show_email_notifications`, a variable CKAN removed in 2.10 (replaced by `h.activity_show_email_notifications()`). Always false on 2.11, regardless of config.
- **The checkbox read the wrong user's preference.** `checked=g.userobj...` (the viewer) instead of `checked=data...` (the profile being edited) - a CKAN 2.9 bug we copied verbatim. On any sysadmin save of another user's profile this silently overwrote that user's real preference with the sysadmin's own. Upstream fixed this themselves when the field moved into `ckanext-activity`; matched here.
- **Sysadmins could not save any change to another user's profile.** `views/user.py` requires the sysadmin's own password to authorize a cross-user edit, but `old_password` was always submitted hidden and empty (added to stop a self-edit crash, untested for cross-user). Every such save failed with a misleading "incorrect password" error. Restored a visible, required password field for that case only, matching CKAN's own current template.

Also fixed: the checkbox rendered stacked above its label (`.dataset-form input { width: 100% }` stretched it) - exempted checkboxes/radios from that rule.

Second commit drops a dead `value=data.oldpassword` argument - verified that key is never set anywhere in CKAN, so it always rendered `value=""` regardless; removing it is a no-op (confirmed by diffing rendered HTML).

**Operational note (not part of this diff):** enabling the config also needs something to trigger sending on a schedule. A cron job authenticating via a sysadmin API token works, but CKAN 2.11 tokens never expire - a permanent credential to manage. Running `ckan notify send_emails` in-process (e.g. via supervisor) needs no token at all. Recommend the latter wherever this gets scheduled; not blocking for this PR.

## Test plan

- [x] Enabled the config locally, sent a real digest via both CLI and cron - delivered to smtp4dev
- [x] Checkbox absent with the old gate, present with the fix
- [x] Checkbox reflects the *target* user's stored preference on cross-user edit (tested both directions)
- [x] Self-edit still submits `old_password` hidden/empty - no behavior change
- [x] "Sysadmin Password" field is required client-side, blocks empty submission
- [x] Full round trip: sysadmin edits another user, enters own password, save persists
- [x] Rendered HTML byte-identical before/after dropping the dead `value=` argument
- [x] Every checkbox/radio in `.dataset-form` app-wide checked - only this one affected by the CSS change